### PR TITLE
feat(tasty-streaming): add NDJSON streaming test reporter package

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ spendPublicKeyOutput = mockchainSucceeds $ do
 
 See [src/coin-selection/test/Spec.hs](src/coin-selection/test/Spec.hs) for more details.
 
+Test suites integrated with `convex-tasty-streaming` support `--streaming-json` (real-time NDJSON output of test results) and `--list-tests-json` (structured JSON test-tree discovery without execution), intended for IDE integrations and external tooling.
+See [src/tasty-streaming/README.md](src/tasty-streaming/README.md) for integration instructions, the NDJSON event schema, and `jq` parsing examples.
+
 ## Working with cardano node
 
 The `node-client` package exposes a simple interface to some of node client functions from `cardano-api`. The main function is `foldClient`:

--- a/cabal.project
+++ b/cabal.project
@@ -26,6 +26,7 @@ test-show-details: direct
 tests: True
 
 packages:
+  src/tasty-streaming
   src/testing-interface
   src/use-cases
 

--- a/src/tasty-streaming/LICENSE
+++ b/src/tasty-streaming/LICENSE
@@ -1,0 +1,53 @@
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. 
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/src/tasty-streaming/README.md
+++ b/src/tasty-streaming/README.md
@@ -1,0 +1,225 @@
+# convex-tasty-streaming
+
+A Tasty ingredient that streams test results as **NDJSON** (newline-delimited JSON) to stdout. Designed for consumption by IDE extensions, VS Code test explorers, and external tooling that need real-time structured test output.
+
+## Integration
+
+### 1. Add the dependency
+
+In your `.cabal` file, add `convex-tasty-streaming` to the test suite's `build-depends`:
+
+```cabal
+test-suite my-tests
+  build-depends:
+    , convex-tasty-streaming
+    , tasty
+    ...
+```
+
+### 2. Replace `defaultMain`
+
+In your test entry point, swap `defaultMain` for `defaultMainStreaming`:
+
+```haskell
+-- Before
+import Test.Tasty (defaultMain)
+
+main :: IO ()
+main = defaultMain tests
+
+-- After
+import Convex.Tasty.Streaming (defaultMainStreaming)
+
+main :: IO ()
+main = defaultMainStreaming tests
+```
+
+`defaultMainStreaming` behaves identically to `defaultMain` by default. The streaming features are only activated when their CLI flags are passed. Normal console output is unchanged.
+
+If you use a wrapper like `withCoverage`, just replace the `defaultMain` call inside it:
+
+```haskell
+main :: IO ()
+main = withCoverage config $ \opts runOpts ->
+  defaultMainStreaming (tests opts runOpts)
+```
+
+### 3. Add the package to `cabal.project`
+
+```
+packages:
+  src/tasty-streaming
+  ...
+```
+
+## Usage
+
+### Discover tests (no execution)
+
+List the full test tree as structured JSON without running any tests:
+
+```bash
+cabal test convex-testing-interface-test --test-options="--list-tests-json"
+```
+
+Combine with Tasty's `-p` pattern flag to filter:
+
+```bash
+cabal test convex-testing-interface-test --test-options="--list-tests-json -p 'ping-pong'"
+```
+
+### Stream test results
+
+Run tests with real-time NDJSON output instead of console output:
+
+```bash
+cabal test convex-testing-interface-test --test-options="--streaming-json"
+```
+
+Combine with pattern filtering:
+
+```bash
+cabal test convex-testing-interface-test --test-options="--streaming-json -p 'ping-pong'"
+```
+
+## NDJSON Event Schema
+
+Each line of output is a self-contained JSON object with an `event` field. Events are emitted in this order:
+
+| Event            | When                           | Fields                                                          |
+|------------------|--------------------------------|-----------------------------------------------------------------|
+| `suite_started`  | Before any test runs           | `tests[]` — array of `{id, name, path}`                        |
+| `test_started`   | A test begins executing        | `id`                                                            |
+| `test_done`      | A test completes               | `id`, `success`, `duration`, `description`, optional `failure`  |
+| `suite_done`     | After all tests finish         | `passed`, `failed`, `duration`                                  |
+
+### `suite_started`
+
+```json
+{
+  "event": "suite_started",
+  "tests": [
+    {"id": 0, "name": "First bid equals minimum bid", "path": ["auction tests", "unit tests"]},
+    {"id": 1, "name": "Positive tests", "path": ["auction tests", "property-based tests"]}
+  ]
+}
+```
+
+- `id` — stable integer index, used to correlate `test_started` and `test_done` events
+- `name` — the test's own name (leaf label in the Tasty tree)
+- `path` — ordered list of group names from root to the test's parent
+
+### `test_started`
+
+```json
+{"event": "test_started", "id": 0}
+```
+
+Emitted when the test transitions from queued to executing.
+
+### `test_done`
+
+Success:
+
+```json
+{"event": "test_done", "id": 0, "success": true, "duration": 0.217, "description": "First bid equals minimum bid"}
+```
+
+Failure:
+
+```json
+{
+  "event": "test_done",
+  "id": 1,
+  "success": false,
+  "duration": 0.456,
+  "description": "Positive tests",
+  "failure": {
+    "reason": "TestFailed",
+    "message": "Expected 1 but got 2"
+  }
+}
+```
+
+### `suite_done`
+
+```json
+{"event": "suite_done", "passed": 55, "failed": 0, "duration": 79.6}
+```
+
+## Parsing with jq
+
+Since `cabal test` prints its own non-JSON lines to stdout (build info, "Running 1 test suites...", etc.), use this pattern to safely parse only the JSON lines:
+
+```bash
+jq -R 'fromjson? // empty'
+```
+
+This reads each line as a raw string (`-R`), tries to parse it as JSON (`fromjson?` — the `?` silently skips failures), and discards any leftovers (`// empty`).
+
+### Examples
+
+**Pretty-print all events:**
+
+```bash
+cabal test convex-testing-interface-test \
+  --test-options="--streaming-json" 2>/dev/null \
+  | jq -R 'fromjson? // empty'
+```
+
+**List the test tree (discovery only):**
+
+```bash
+cabal test convex-testing-interface-test \
+  --test-options="--list-tests-json" 2>/dev/null \
+  | jq -R 'fromjson? // empty | .tests[] | {id, name, path}'
+```
+
+**Show only failures:**
+
+```bash
+cabal test convex-testing-interface-test \
+  --test-options="--streaming-json" 2>/dev/null \
+  | jq -R 'fromjson? // empty | select(.event == "test_done" and .success == false)'
+```
+
+**Extract test names and durations as a table:**
+
+```bash
+cabal test convex-testing-interface-test \
+  --test-options="--streaming-json" 2>/dev/null \
+  | jq -r -R 'fromjson? // empty | select(.event == "test_done") | [.id, .duration, .description] | @tsv'
+```
+
+**Get the final summary:**
+
+```bash
+cabal test convex-testing-interface-test \
+  --test-options="--streaming-json" 2>/dev/null \
+  | jq -R 'fromjson? // empty | select(.event == "suite_done")'
+```
+
+**Count tests per top-level group:**
+
+```bash
+cabal test convex-testing-interface-test \
+  --test-options="--list-tests-json" 2>/dev/null \
+  | jq -R 'fromjson? // empty | .tests | group_by(.path[0]) | map({group: .[0].path[0], count: length})'
+```
+
+**Filter discovery by path:**
+
+```bash
+cabal test convex-testing-interface-test \
+  --test-options="--list-tests-json -p 'ping-pong'" 2>/dev/null \
+  | jq -R 'fromjson? // empty | .tests[] | {id, name, path}'
+```
+
+## API Reference
+
+| Export                     | Type         | Description                                                          |
+|----------------------------|--------------|----------------------------------------------------------------------|
+| `defaultMainStreaming`     | `TestTree -> IO ()` | Drop-in replacement for `defaultMain` with streaming support   |
+| `streamingJsonReporter`    | `Ingredient` | The `--streaming-json` reporter (real-time NDJSON during test runs)   |
+| `listTestsJsonIngredient`  | `Ingredient` | The `--list-tests-json` manager (test discovery without execution)   |
+| `streamingIngredients`     | `[Ingredient]` | All ingredients combined (listing + JSON discovery + streaming + console) |

--- a/src/tasty-streaming/convex-tasty-streaming.cabal
+++ b/src/tasty-streaming/convex-tasty-streaming.cabal
@@ -1,0 +1,55 @@
+cabal-version: 3.0
+name:          convex-tasty-streaming
+version:       0.1.0.0
+synopsis:      Streaming NDJSON test reporter for Tasty
+license:       Apache-2.0
+license-files: LICENSE
+maintainer:    bogdan.manole@iohk.io
+author:        Bogdan Manole
+description:
+  A Tasty ingredient that streams test results as newline-delimited JSON (NDJSON)
+  to stdout. Designed for consumption by IDE extensions and external tooling
+  that need real-time structured test output.
+
+build-type:    Simple
+
+common lang
+  default-language:   Haskell2010
+  default-extensions:
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    ExplicitForAll
+    FlexibleContexts
+    GeneralizedNewtypeDeriving
+    ImportQualifiedPost
+    MultiParamTypeClasses
+    OverloadedStrings
+    ScopedTypeVariables
+    StandaloneDeriving
+
+  ghc-options:
+    -Wall -Wnoncanonical-monad-instances -Wunused-packages
+    -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wredundant-constraints -Widentities
+
+library
+  import:          lang
+  exposed-modules:
+    Convex.Tasty.Streaming
+    Convex.Tasty.Streaming.TreeMap
+    Convex.Tasty.Streaming.Types
+
+  hs-source-dirs:  lib
+  build-depends:
+    , aeson
+    , async
+    , base        >=4.14.0
+    , bytestring
+    , containers
+    , stm
+    , tagged
+    , tasty       >=1.4
+    , text

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
@@ -1,0 +1,172 @@
+module Convex.Tasty.Streaming (
+  streamingJsonReporter,
+  listTestsJsonIngredient,
+  streamingIngredients,
+  defaultMainStreaming,
+) where
+
+import Control.Concurrent.Async (forConcurrently_)
+import Control.Concurrent.MVar (newMVar, withMVar)
+import Control.Concurrent.STM
+import Convex.Tasty.Streaming.TreeMap (buildTestMap)
+import Convex.Tasty.Streaming.Types
+import Data.Aeson (encode)
+import Data.ByteString.Lazy.Char8 qualified as BL8
+import Data.IntMap.Strict qualified as IntMap
+import Data.Proxy (Proxy (..))
+import Data.Tagged (Tagged (..))
+import Data.Text qualified as Text
+import Data.Typeable (Typeable)
+import System.IO (BufferMode (..), hFlush, hSetBuffering, stdout)
+import Test.Tasty (TestTree, defaultMainWithIngredients)
+import Test.Tasty.Ingredients (Ingredient (..))
+import Test.Tasty.Ingredients.ConsoleReporter (consoleTestReporter)
+import Test.Tasty.Options (IsOption (..), OptionDescription (..), lookupOption, mkFlagCLParser, safeRead)
+import Test.Tasty.Runners (
+  FailureReason (..),
+  Outcome (..),
+  Result (..),
+  Status (..),
+  listingTests,
+ )
+
+-- | Command-line option to enable streaming JSON output
+newtype StreamingJson = StreamingJson Bool
+  deriving (Eq, Ord, Typeable)
+
+instance IsOption StreamingJson where
+  defaultValue = StreamingJson False
+  parseValue = fmap StreamingJson . safeRead
+  optionName = Tagged "streaming-json"
+  optionHelp = Tagged "Enable streaming NDJSON test output to stdout"
+  optionCLParser = mkFlagCLParser mempty (StreamingJson True)
+
+-- | Command-line option to list tests as JSON without running them
+newtype ListTestsJson = ListTestsJson Bool
+  deriving (Eq, Ord, Typeable)
+
+instance IsOption ListTestsJson where
+  defaultValue = ListTestsJson False
+  parseValue = fmap ListTestsJson . safeRead
+  optionName = Tagged "list-tests-json"
+  optionHelp = Tagged "List all tests as a JSON object and exit without running"
+  optionCLParser = mkFlagCLParser mempty (ListTestsJson True)
+
+{- | The streaming JSON reporter ingredient.
+
+When activated via @--streaming-json@, replaces console output with
+newline-delimited JSON events streamed to stdout.
+-}
+streamingJsonReporter :: Ingredient
+streamingJsonReporter = TestReporter
+  [Option (Proxy :: Proxy StreamingJson)]
+  $ \opts tree -> do
+    let StreamingJson enabled = lookupOption opts
+    if not enabled
+      then Nothing
+      else Just $ \statusMap -> do
+        -- Set line buffering for streaming
+        hSetBuffering stdout LineBuffering
+
+        -- Create lock for thread-safe output
+        outputLock <- newMVar ()
+        let emit evt = withMVar outputLock $ \_ -> emitEvent evt
+
+        -- Build the test index -> metadata map
+        testMap <- buildTestMap opts tree
+
+        -- Emit suite_started with full test list
+        let testInfos = map snd $ IntMap.toAscList testMap
+        emit $ SuiteStarted testInfos
+
+        -- Track results for final summary
+        resultsVar <- newTVarIO ([] :: [(Int, Result)])
+
+        -- Watch each test concurrently
+        forConcurrently_ (IntMap.toAscList statusMap) $ \(idx, statusTVar) -> do
+          -- Wait until the test starts
+          atomically $ do
+            status <- readTVar statusTVar
+            case status of
+              NotStarted -> retry
+              _ -> pure ()
+
+          -- Emit test_started
+          emit $ TestStarted idx
+
+          -- Wait for completion
+          result <- atomically $ do
+            status <- readTVar statusTVar
+            case status of
+              Done r -> pure r
+              _ -> retry
+
+          -- Record result
+          atomically $ modifyTVar' resultsVar ((idx, result) :)
+
+          -- Emit test_done
+          let testName = maybe "" tiName (IntMap.lookup idx testMap)
+          let outcome = case resultOutcome result of
+                Success -> TestSuccess
+                Failure reason ->
+                  TestFailure $
+                    FailureInfo
+                      { fiReason = Text.pack $ showFailureReason reason
+                      , fiMessage = Text.pack $ resultDescription result
+                      }
+          emit $ TestDone idx outcome (resultTime result) testName
+
+        -- Emit suite_done summary
+        allResults <- readTVarIO resultsVar
+        let passed = length [() | (_, r) <- allResults, isSuccess r]
+        let failed = length allResults - passed
+
+        -- Return the "finalize" callback
+        pure $ \totalTime -> do
+          emit $ SuiteDone passed failed totalTime
+          pure (failed == 0)
+
+-- | Emit a single NDJSON event line to stdout
+emitEvent :: Event -> IO ()
+emitEvent evt = do
+  BL8.putStrLn (encode evt)
+  hFlush stdout
+
+-- | Check if a Result is a success
+isSuccess :: Result -> Bool
+isSuccess r = case resultOutcome r of
+  Success -> True
+  _ -> False
+
+-- | Show a FailureReason as text
+showFailureReason :: FailureReason -> String
+showFailureReason TestFailed = "TestFailed"
+showFailureReason (TestThrewException e) = "TestThrewException: " ++ show e
+showFailureReason (TestTimedOut n) = "TestTimedOut: " ++ show n ++ "μs"
+showFailureReason TestDepFailed = "TestDepFailed"
+
+{- | Ingredient that lists the test tree as JSON and exits without running tests.
+
+Activated via @--list-tests-json@.
+-}
+listTestsJsonIngredient :: Ingredient
+listTestsJsonIngredient = TestManager
+  [Option (Proxy :: Proxy ListTestsJson)]
+  $ \opts tree -> do
+    let ListTestsJson enabled = lookupOption opts
+    if not enabled
+      then Nothing
+      else Just $ do
+        hSetBuffering stdout LineBuffering
+        testMap <- buildTestMap opts tree
+        let testInfos = map snd $ IntMap.toAscList testMap
+        emitEvent $ SuiteStarted testInfos
+        pure True
+
+-- | Default ingredients with streaming reporter added
+streamingIngredients :: [Ingredient]
+streamingIngredients = [listingTests, listTestsJsonIngredient, streamingJsonReporter, consoleTestReporter]
+
+-- | Drop-in replacement for 'defaultMain' that supports @--streaming-json@.
+defaultMainStreaming :: TestTree -> IO ()
+defaultMainStreaming = defaultMainWithIngredients streamingIngredients

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming/TreeMap.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming/TreeMap.hs
@@ -1,0 +1,45 @@
+module Convex.Tasty.Streaming.TreeMap (
+  buildTestMap,
+) where
+
+import Convex.Tasty.Streaming.Types (TestInfo (..))
+import Data.IORef
+import Data.IntMap.Strict (IntMap)
+import Data.IntMap.Strict qualified as IntMap
+import Data.Text qualified as Text
+import Test.Tasty (TestTree)
+import Test.Tasty.Options (OptionSet)
+import Test.Tasty.Runners (Ap (..), TreeFold (..), foldTestTree, trivialFold)
+
+{- | Build a mapping from StatusMap integer indices to test metadata.
+
+The indices correspond to the order tests appear during a fold of the TestTree,
+which is the same order Tasty uses when building the StatusMap.
+-}
+buildTestMap :: OptionSet -> TestTree -> IO (IntMap TestInfo)
+buildTestMap opts tree = do
+  counterRef <- newIORef (0 :: Int)
+  let Ap action = foldTestTree (mkFold counterRef) opts tree
+  action
+
+mkFold :: IORef Int -> TreeFold (Ap IO (IntMap TestInfo))
+mkFold counterRef =
+  (trivialFold :: TreeFold (Ap IO (IntMap TestInfo)))
+    { foldSingle = \_ name _ -> Ap $ do
+        idx <- readIORef counterRef
+        modifyIORef' counterRef (+ 1)
+        let info =
+              TestInfo
+                { tiId = idx
+                , tiName = Text.pack name
+                , tiPath = []
+                }
+        pure $ IntMap.singleton idx info
+    , foldGroup = \_opts groupName children -> Ap $ do
+        let Ap childAction = mconcat children
+        childMap <- childAction
+        let prependGroup ti = ti{tiPath = Text.pack groupName : tiPath ti}
+        pure $ fmap prependGroup childMap
+    , foldResource = \_ _ k ->
+        k (error "Convex.Tasty.Streaming.TreeMap: resource not available during fold")
+    }

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming/Types.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming/Types.hs
@@ -1,0 +1,112 @@
+module Convex.Tasty.Streaming.Types (
+  Event (..),
+  TestInfo (..),
+  TestOutcome (..),
+  FailureInfo (..),
+) where
+
+import Data.Aeson (ToJSON (..), object, (.=))
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+-- | Information about a single test in the tree
+data TestInfo = TestInfo
+  { tiId :: !Int
+  , tiName :: !Text
+  , tiPath :: ![Text]
+  }
+  deriving (Eq, Show, Generic)
+
+instance ToJSON TestInfo where
+  toJSON (TestInfo i n p) =
+    object
+      [ "id" .= i
+      , "name" .= n
+      , "path" .= p
+      ]
+
+-- | Outcome of a completed test
+data TestOutcome
+  = TestSuccess
+  | TestFailure !FailureInfo
+  deriving (Eq, Show, Generic)
+
+-- | Details about a test failure
+data FailureInfo = FailureInfo
+  { fiReason :: !Text
+  , fiMessage :: !Text
+  }
+  deriving (Eq, Show, Generic)
+
+instance ToJSON FailureInfo where
+  toJSON (FailureInfo r m) =
+    object
+      [ "reason" .= r
+      , "message" .= m
+      ]
+
+-- | A streaming event emitted as a single NDJSON line
+data Event
+  = SuiteStarted
+      { esTests :: ![TestInfo]
+      }
+  | TestStarted
+      { etId :: !Int
+      }
+  | TestProgress
+      { epId :: !Int
+      , epMessage :: !Text
+      , epPercent :: !Float
+      }
+  | TestDone
+      { edId :: !Int
+      , edOutcome :: !TestOutcome
+      , edDuration :: !Double
+      , edDescription :: !Text
+      }
+  | SuiteDone
+      { esPassed :: !Int
+      , esFailed :: !Int
+      , esDuration :: !Double
+      }
+  deriving (Eq, Show, Generic)
+
+instance ToJSON Event where
+  toJSON (SuiteStarted ts) =
+    object
+      [ "event" .= ("suite_started" :: Text)
+      , "tests" .= ts
+      ]
+  toJSON (TestStarted i) =
+    object
+      [ "event" .= ("test_started" :: Text)
+      , "id" .= i
+      ]
+  toJSON (TestProgress i msg pct) =
+    object
+      [ "event" .= ("test_progress" :: Text)
+      , "id" .= i
+      , "message" .= msg
+      , "percent" .= pct
+      ]
+  toJSON (TestDone i outcome dur desc) =
+    object $
+      [ "event" .= ("test_done" :: Text)
+      , "id" .= i
+      , "duration" .= dur
+      , "description" .= desc
+      ]
+        <> outcomeFields outcome
+   where
+    outcomeFields TestSuccess = ["success" .= True]
+    outcomeFields (TestFailure fi) =
+      [ "success" .= False
+      , "failure" .= fi
+      ]
+  toJSON (SuiteDone p f dur) =
+    object
+      [ "event" .= ("suite_done" :: Text)
+      , "passed" .= p
+      , "failed" .= f
+      , "duration" .= dur
+      ]

--- a/src/testing-interface/convex-testing-interface.cabal
+++ b/src/testing-interface/convex-testing-interface.cabal
@@ -156,6 +156,7 @@ test-suite convex-testing-interface-test
     , convex-coin-selection
     , convex-mockchain
     , convex-optics
+    , convex-tasty-streaming
     , convex-testing-interface
     , convex-wallet
     , lens

--- a/src/testing-interface/test/Spec.hs
+++ b/src/testing-interface/test/Spec.hs
@@ -2,6 +2,7 @@
 
 import Cardano.Api qualified as C
 import Convex.MockChain.Utils (mockchainFails)
+import Convex.Tasty.Streaming (defaultMainStreaming)
 import Convex.TestingInterface (
   CoverageConfig (..),
   Options,
@@ -12,7 +13,7 @@ import Convex.TestingInterface (
   writeCoverageReport,
  )
 import Convex.Utils (failOnError)
-import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase)
 
 import AikenBankSpec (aikenBankTests)
@@ -43,7 +44,7 @@ main = withCoverage config $ \opts0 runOpts0 ->
     opts = modifyTransactionLimits opts0 30_000
     runOpts = runOpts0{mcOptions = opts}
    in
-    defaultMain (tests opts runOpts)
+    defaultMainStreaming (tests opts runOpts)
  where
   config =
     CoverageConfig

--- a/src/use-cases/convex-use-cases.cabal
+++ b/src/use-cases/convex-use-cases.cabal
@@ -103,6 +103,7 @@ test-suite convex-auction-test
     , convex-coin-selection
     , convex-mockchain
     , convex-optics
+    , convex-tasty-streaming
     , convex-testing-interface
     , convex-wallet
     , katip
@@ -146,6 +147,7 @@ test-suite convex-escrow-test
     , convex-coin-selection
     , convex-mockchain
     , convex-optics
+    , convex-tasty-streaming
     , convex-testing-interface
     , convex-wallet
     , katip
@@ -191,6 +193,7 @@ test-suite convex-multiplayerpingpong-test
     , convex-coin-selection
     , convex-mockchain
     , convex-optics
+    , convex-tasty-streaming
     , convex-testing-interface
     , convex-wallet
     , katip
@@ -235,6 +238,7 @@ test-suite convex-vesting-test
     , convex-coin-selection
     , convex-mockchain
     , convex-optics
+    , convex-tasty-streaming
     , convex-testing-interface
     , convex-wallet
     , lens

--- a/src/use-cases/test/Auction/Spec/Spec.hs
+++ b/src/use-cases/test/Auction/Spec/Spec.hs
@@ -5,14 +5,15 @@ module Main where
 import Auction.Spec.Attacks (attackTests)
 import Auction.Spec.Prop (propBasedTests)
 import Auction.Spec.Unit (unitTests)
-import Test.Tasty (TestTree, defaultMain, testGroup)
+import Convex.Tasty.Streaming (defaultMainStreaming)
+import Test.Tasty (TestTree, testGroup)
 
 --------------------------------------------------------------------------------
 -- Main Test Entry Point
 --------------------------------------------------------------------------------
 
 main :: IO ()
-main = defaultMain tests
+main = defaultMainStreaming tests
 
 tests :: TestTree
 tests =

--- a/src/use-cases/test/Escrow/Spec/Spec.hs
+++ b/src/use-cases/test/Escrow/Spec/Spec.hs
@@ -3,15 +3,16 @@
 module Main where
 
 import Escrow.Spec.Prop (propBasedTests)
+import Convex.Tasty.Streaming (defaultMainStreaming)
 import Escrow.Spec.Unit (unitTests)
-import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty (TestTree, testGroup)
 
 --------------------------------------------------------------------------------
 -- Main Test Entry Point
 --------------------------------------------------------------------------------
 
 main :: IO ()
-main = defaultMain tests
+main = defaultMainStreaming tests
 
 tests :: TestTree
 tests =

--- a/src/use-cases/test/MultiPlayerPingPong/Spec/Spec.hs
+++ b/src/use-cases/test/MultiPlayerPingPong/Spec/Spec.hs
@@ -2,16 +2,17 @@
 
 module Main where
 
+import Convex.Tasty.Streaming (defaultMainStreaming)
 import MultiPlayerPingPong.Spec.Prop (propBasedTests)
 import MultiPlayerPingPong.Spec.Unit (unitTests)
-import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty (TestTree, testGroup)
 
 --------------------------------------------------------------------------------
 -- Main Test Entry Point
 --------------------------------------------------------------------------------
 
 main :: IO ()
-main = defaultMain tests
+main = defaultMainStreaming tests
 
 tests :: TestTree
 tests =

--- a/src/use-cases/test/Vesting/Spec/Spec.hs
+++ b/src/use-cases/test/Vesting/Spec/Spec.hs
@@ -8,11 +8,11 @@ import Cardano.Ledger.Plutus.ExUnits (ExUnits (exUnitsMem))
 import Control.Lens ((%~), (&))
 import Convex.NodeParams (NodeParams (..))
 import Convex.NodeParams qualified as NP
+import Convex.Tasty.Streaming (defaultMainStreaming)
 import Convex.TestingInterface (Options (..), RunOptions (..), defaultOptions, defaultRunOptions)
 import Data.Functor.Identity (Identity)
 import Test.Tasty (
   TestTree,
-  defaultMain,
   testGroup,
  )
 import Vesting.Spec.Prop qualified
@@ -42,7 +42,7 @@ main =
     opts = modifyMemoryLimit defaultOptions
     runOpts = defaultRunOptions{mcOptions = opts}
    in
-    defaultMain (tests opts runOpts)
+    defaultMainStreaming (tests opts runOpts)
 
 tests :: Options C.ConwayEra -> RunOptions -> TestTree
 tests _opts runOpts =


### PR DESCRIPTION
Fixes #31 

- New package convex-tasty-streaming with a Tasty ingredient that streams test results as newline-delimited JSON to stdout
- Adds --streaming-json flag for real-time test output (suite_started, test_started, test_done, suite_done events) with hierarchical test paths and structured failure info
- Adds --list-tests-json flag for test-tree discovery without execution
- defaultMainStreaming drop-in replacement preserves normal console output when flags are not set
- Integrate into all five test suites (testing-interface, auction, escrow, multiplayerpingpong, vesting)
- Document integration, NDJSON event schema, and jq parsing examples in src/tasty-streaming/README.md with pointer from main README


Usage:

### 1. runs all ping-pong related tests streaming json for the output
```bash
cabal run convex-testing-interface-test -- -p 'ping-pong' --streaming-json  
```

### 2. just listing the tests
```bash
 cabal run convex-testing-interface-test -- --list-tests-json
```