### PR TITLE
feat(tasty-streaming): stream threat-model summaries on test_done events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ tmp/
 
 # MacOS
 **/.DS_Store
+sss.json

--- a/PLAN-iteration-trace-streaming.md
+++ b/PLAN-iteration-trace-streaming.md
@@ -1,0 +1,695 @@
+# Plan: Iteration Trace Streaming for VS Code Extension
+
+## Context & Goal
+
+The `sc-tools` project has a property-based testing framework (`convex-testing-interface`) for Cardano smart contracts, and a streaming NDJSON reporter (`convex-tasty-streaming`) that emits test events consumed by a VS Code extension.
+
+**Current state:** The streaming emits high-level events (`suite_started`, `test_started`, `test_done`, `suite_done`) with aggregate `ThreatModelSummary` (just counts). This is sufficient for a test runner UI but not for debugging.
+
+**Goal:** Enable the VS Code extension to visually display:
+1. **State transitions** — For each QuickCheck iteration, show the sequence of actions performed, the model state before/after each action, and the transaction produced.
+2. **Threat model details** — For each transaction in an iteration, show how a threat model modified it, what the modified tx looks like, and whether the ledger accepted/rejected it.
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  TestingInterface framework (propRunActionsWithOptions)           │
+│  Already controls: initialize → runActions loop → threat models  │
+│  We instrument HERE (invisible to user)                          │
+└───────────────────────────────┬──────────────────────────────────┘
+                                │ produces
+                                ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  Trace Data Types (new module: Convex.TestingInterface.Trace)     │
+│  Pure Haskell types with ToJSON instances                         │
+│  Delivery-agnostic: just data                                    │
+└───────────────────────────────┬──────────────────────────────────┘
+                                │ stored in
+                                ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  Trace Store (new module: Convex.TestingInterface.Trace.Store)    │
+│  Thread-safe IORef-based store, same pattern as TMStore           │
+│  Keyed by Tasty test path                                        │
+└───────────────────────────────┬──────────────────────────────────┘
+                                │ read by
+                                ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  Streaming Layer (extends convex-tasty-streaming)                 │
+│  New event type `iteration_trace` emitted after `test_done`      │
+│  Or: written to sidecar file referenced in `test_done`           │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## Data Types
+
+### File: `src/testing-interface/lib/Convex/TestingInterface/Trace.hs`
+
+```haskell
+module Convex.TestingInterface.Trace
+  ( TestRunTrace(..)
+  , TestCategory(..)
+  , IterationTrace(..)
+  , IterationStatus(..)
+  , Transition(..)
+  , TransitionResult(..)
+  , TxSummary(..)
+  , TxInputSummary(..)
+  , TxOutputSummary(..)
+  , ThreatModelTrace(..)
+  , ThreatModelTraceOutcome(..)
+  ) where
+
+import Data.Aeson (ToJSON(..), object, (.=))
+import Data.Text (Text)
+import Cardano.Api qualified as C
+
+-- | Complete trace of a test run (one QuickCheck property = N iterations)
+data TestRunTrace = TestRunTrace
+  { trtTestId    :: !Int          -- Tasty test ID (links to Event stream's test_done)
+  , trtTestName  :: !Text         -- e.g. "Positive tests"
+  , trtPath      :: ![Text]       -- e.g. ["MyContract", "Positive tests"]
+  , trtCategory  :: !TestCategory
+  , trtIterations :: ![IterationTrace]
+  }
+
+data TestCategory = Positive | Negative
+  deriving (Eq, Show)
+
+-- | Trace of a single QuickCheck iteration
+data IterationTrace = IterationTrace
+  { itIndex       :: !Int              -- 0-based iteration number
+  , itSeed        :: !Int              -- QuickCheck seed for reproducibility
+  , itStatus      :: !IterationStatus
+  , itTransitions :: ![Transition]     -- ordered action sequence
+  , itThreatModels :: ![ThreatModelTrace]  -- threat model results for this iteration's txs
+  }
+
+data IterationStatus
+  = IterationSuccess
+  | IterationFailure !Text     -- error message
+  | IterationDiscarded !Text   -- reason it was discarded
+  deriving (Eq, Show)
+
+-- | One step in the iteration: action → state change → transaction
+data Transition = Transition
+  { trStepIndex   :: !Int
+  , trAction      :: !Text           -- Show of the Action value
+  , trStateBefore :: !Value          -- ToJSON of model state before perform
+  , trStateAfter  :: !Value          -- ToJSON of model state after perform
+  , trTransaction :: !(Maybe TxSummary)  -- Nothing if perform failed before building tx
+  , trResult      :: !TransitionResult
+  }
+
+data TransitionResult
+  = TransitionSuccess !Text    -- TxId as text
+  | TransitionFailure !Text    -- BalanceTxError description
+  deriving (Eq, Show)
+
+-- | Compact representation of a transaction for visualization
+data TxSummary = TxSummary
+  { txsId         :: !(Maybe Text)       -- TxId if submitted, Nothing if not
+  , txsInputs     :: ![TxInputSummary]
+  , txsOutputs    :: ![TxOutputSummary]
+  , txsMint       :: !(Maybe Text)       -- Rendered value if non-zero mint
+  , txsFee        :: !Integer            -- Lovelace fee
+  , txsSigners    :: ![Text]             -- Required signer key hashes
+  , txsValidRange :: !(Maybe Text)       -- Rendered validity interval
+  }
+
+data TxInputSummary = TxInputSummary
+  { tisRef     :: !Text    -- "txid#index"
+  , tisAddress :: !Text    -- Bech32 or hex
+  , tisValue   :: !Text    -- Rendered value (ada + tokens)
+  }
+
+data TxOutputSummary = TxOutputSummary
+  { tosIndex   :: !Int
+  , tosAddress :: !Text
+  , tosValue   :: !Text
+  , tosDatum   :: !(Maybe Text)  -- "inline:<hash>" or "hash:<hash>" or Nothing
+  }
+
+-- | What happened when a threat model was applied to one of this iteration's txs
+data ThreatModelTrace = ThreatModelTrace
+  { tmtName           :: !Text
+  , tmtTargetTxIndex  :: !Int              -- index into itTransitions
+  , tmtModifications  :: ![Text]           -- human-readable mod descriptions
+  , tmtOriginalTx     :: !TxSummary
+  , tmtModifiedTx     :: !(Maybe TxSummary)  -- Nothing if modification couldn't produce a valid tx body
+  , tmtOutcome        :: !ThreatModelTraceOutcome
+  }
+
+data ThreatModelTraceOutcome
+  = TMTOPassed            -- modified tx was rejected (good!)
+  | TMTOFailed !Text      -- modified tx was ACCEPTED (vulnerability found)
+  | TMTOSkipped !Text     -- couldn't test (rebalancing failed, precondition unmet)
+  | TMTOError !Text       -- unexpected error
+  deriving (Eq, Show)
+```
+
+All types get `ToJSON` instances. The JSON schema should be:
+
+```json
+{
+  "testId": 3,
+  "testName": "Positive tests",
+  "path": ["MyContract", "Positive tests"],
+  "category": "positive",
+  "iterations": [
+    {
+      "index": 0,
+      "seed": 12345,
+      "status": "success",
+      "transitions": [
+        {
+          "stepIndex": 0,
+          "action": "Deposit (Wallet 1) (Value 50000000)",
+          "stateBefore": {"balance": 0, "owner": "addr_test1..."},
+          "stateAfter": {"balance": 50000000, "owner": "addr_test1..."},
+          "transaction": {
+            "id": "abc123...",
+            "inputs": [{"ref": "def456...#0", "address": "addr_test1...", "value": "100 ADA"}],
+            "outputs": [{"index": 0, "address": "addr_test1...", "value": "50 ADA", "datum": "inline:abc..."}],
+            "mint": null,
+            "fee": 200000,
+            "signers": ["abc123..."],
+            "validRange": "[0, +inf)"
+          },
+          "result": {"status": "success", "txId": "abc123..."}
+        }
+      ],
+      "threatModels": [
+        {
+          "name": "unprotectedScriptOutput",
+          "targetTxIndex": 0,
+          "modifications": ["Changed output #0 value: removed 10 ADA"],
+          "originalTx": { "..." : "..." },
+          "modifiedTx": { "..." : "..." },
+          "outcome": {"status": "passed"}
+        }
+      ]
+    }
+  ]
+}
+```
+
+### File: `src/testing-interface/lib/Convex/TestingInterface/Trace/Store.hs`
+
+```haskell
+module Convex.TestingInterface.Trace.Store
+  ( TraceStore
+  , TraceRecorder(..)
+  , TraceStoreOption(..)
+  , newTraceStore
+  , storeTraceRecorder
+  , lookupTrace
+  , lookupAllTraces
+  ) where
+
+-- | Thread-safe store for iteration traces, keyed by test path.
+newtype TraceStore = TraceStore (IORef (Map String [IterationTrace]))
+
+-- | Recorder closure passed to test bodies via Tasty option system.
+-- Default is no-op (when streaming is not active).
+newtype TraceRecorder = TraceRecorder
+  { recordIteration :: String -> IterationTrace -> IO ()
+  }
+
+instance IsOption TraceRecorder where
+  defaultValue = TraceRecorder (\_ _ -> pure ())
+  -- ...
+
+newtype TraceStoreOption = TraceStoreOption (Maybe TraceStore)
+
+instance IsOption TraceStoreOption where
+  defaultValue = TraceStoreOption Nothing
+  -- ...
+
+newTraceStore :: IO TraceStore
+storeTraceRecorder :: TraceStore -> TraceRecorder
+lookupTrace :: TraceStore -> String -> IO (Maybe [IterationTrace])
+lookupAllTraces :: TraceStore -> IO (Map String [IterationTrace])
+```
+
+## Implementation: Recording Traces (Invisible to User)
+
+### Constraint Change
+
+In `Convex.TestingInterface`:
+
+```haskell
+-- BEFORE:
+class (Show state, Eq state, Show (Action state)) => TestingInterface state where
+
+-- AFTER:
+class (Show state, Eq state, Show (Action state), ToJSON state) => TestingInterface state where
+```
+
+This is the ONLY user-facing change. Users must add `ToJSON` to their state type and `deriving (Generic)` + `instance ToJSON MyState` (or hand-write it).
+
+### Instrumenting `runActions`
+
+The current `runActions` loop:
+
+```haskell
+runActions :: (TestingInterface state, MonadIO m) => RunOptions -> Int -> state -> TestingMonadT (PropertyM m) state
+runActions _ 0 s = pure s
+runActions opts i s = do
+  mAction <- lift $ genAction s
+  case mAction of
+    Just action -> runAction opts s action >>= runActions opts (i - 1)
+    Nothing -> pure s
+```
+
+We create a new variant `runActionsTraced` that accumulates `[Transition]`:
+
+```haskell
+runActionsTraced
+  :: (TestingInterface state, MonadIO m)
+  => RunOptions
+  -> Int
+  -> state
+  -> TestingMonadT (PropertyM m) (state, [Transition])
+runActionsTraced opts maxActions initialState = go 0 initialState []
+  where
+    go stepIdx state acc
+      | stepIdx >= maxActions = pure (state, reverse acc)
+      | otherwise = do
+          mAction <- lift $ genAction state
+          case mAction of
+            Nothing -> pure (state, reverse acc)
+            Just action -> do
+              let stateBefore = toJSON state
+                  actionText = Text.pack (show action)
+              -- Snapshot tx count before perform
+              txCountBefore <- getTxCount
+              -- Run the action
+              result <- tryPerform state action
+              case result of
+                Right newState -> do
+                  let stateAfter = toJSON newState
+                  -- Get the tx that was just submitted (if any)
+                  mTxSummary <- getLastSubmittedTxSummary txCountBefore
+                  let txId = maybe Nothing txsId mTxSummary
+                      transition = Transition
+                        { trStepIndex = stepIdx
+                        , trAction = actionText
+                        , trStateBefore = stateBefore
+                        , trStateAfter = stateAfter
+                        , trTransaction = mTxSummary
+                        , trResult = TransitionSuccess (fromMaybe "" txId)
+                        }
+                  go (stepIdx + 1) newState (transition : acc)
+                Left err -> do
+                  let transition = Transition
+                        { trStepIndex = stepIdx
+                        , trAction = actionText
+                        , trStateBefore = stateBefore
+                        , trStateAfter = stateBefore  -- state unchanged on failure
+                        , trTransaction = Nothing
+                        , trResult = TransitionFailure (Text.pack (show err))
+                        }
+                  -- For positive tests, a failure here means the iteration fails
+                  pure (state, reverse (transition : acc))
+```
+
+Key helpers needed:
+
+```haskell
+-- Get number of successfully submitted txs so far
+getTxCount :: (MonadMockchain era m) => m Int
+getTxCount = length . mcsTransactions <$> getMockChainState
+
+-- Get the tx submitted since txCountBefore, summarize it
+getLastSubmittedTxSummary :: (MonadMockchain era m) => Int -> m (Maybe TxSummary)
+getLastSubmittedTxSummary countBefore = do
+  state <- getMockChainState
+  let txs = mcsTransactions state
+      newTxs = drop countBefore txs
+  case newTxs of
+    ((validatedTx, _) : _) -> pure (Just (summarizeTx validatedTx (mcsPoolState state)))
+    [] -> pure Nothing
+
+-- Try to perform, catching BalanceTxError
+tryPerform :: (TestingInterface state, MonadIO m)
+  => state -> Action state -> TestingMonadT (PropertyM m) (Either (BalanceTxError ConwayEra) state)
+```
+
+### Instrumenting `positiveTest`
+
+In the existing `positiveTest` function, replace:
+```haskell
+finalState <- runActions opts 10 initialState
+```
+with:
+```haskell
+(finalState, transitions) <- runActionsTraced opts 10 initialState
+```
+
+Then after running threat models, construct the `IterationTrace`:
+```haskell
+let iterTrace = IterationTrace
+      { itIndex = iterationNumber  -- need to thread this through
+      , itSeed = seed              -- from QuickCheck
+      , itStatus = IterationSuccess
+      , itTransitions = transitions
+      , itThreatModels = threatModelTraces  -- built from tmResults (see below)
+      }
+```
+
+And record it:
+```haskell
+case mTraceRecorder of
+  Just recorder -> liftIO $ recordIteration recorder testKey iterTrace
+  Nothing -> pure ()
+```
+
+### Instrumenting Threat Model Runner
+
+The current `runThreatModelCheck` returns `ThreatModelOutcome`. We need a richer version that also returns trace data.
+
+Create `runThreatModelCheckTraced`:
+
+```haskell
+data ThreatModelStepTrace = ThreatModelStepTrace
+  { tmstTargetTxIndex :: !Int
+  , tmstModifications :: ![Text]      -- from TxModifier
+  , tmstOriginalTx    :: !TxSummary
+  , tmstModifiedTx    :: !(Maybe TxSummary)
+  , tmstValidationResult :: !ThreatModelTraceOutcome
+  }
+
+runThreatModelCheckTraced
+  :: (MonadMockchain Era m, MonadFail m, MonadIO m)
+  => SigningWallet
+  -> ThreatModel a
+  -> [ThreatModelEnv]
+  -> m (ThreatModelOutcome, [ThreatModelStepTrace])
+```
+
+This wraps the existing `runThreatModelCheck` logic but additionally:
+1. When `Validate mods k` is encountered: records the `mods` as `[Text]` (pretty-print each `TxMod`), summarizes the original tx from `ThreatModelEnv.currentTx`, summarizes the modified tx after `applyTxModifier`
+2. Accumulates these into a list alongside the outcome
+
+The pretty-printing of `TxMod` values uses the existing `Convex.ThreatModel.Pretty` module (or extends it).
+
+### Converting ThreatModelStepTrace → ThreatModelTrace
+
+After running all threat models for an iteration:
+
+```haskell
+buildThreatModelTraces :: [(Text, ThreatModelOutcome, [ThreatModelStepTrace])] -> [ThreatModelTrace]
+buildThreatModelTraces results =
+  [ ThreatModelTrace
+      { tmtName = name
+      , tmtTargetTxIndex = tmstTargetTxIndex step
+      , tmtModifications = tmstModifications step
+      , tmtOriginalTx = tmstOriginalTx step
+      , tmtModifiedTx = tmstModifiedTx step
+      , tmtOutcome = mapOutcome outcome
+      }
+  | (name, outcome, steps) <- results
+  , step <- steps  -- one ThreatModelTrace per step (per tx tested)
+  ]
+```
+
+### Building TxSummary
+
+```haskell
+-- File: src/testing-interface/lib/Convex/TestingInterface/Trace/TxSummary.hs
+
+summarizeTx :: C.Tx C.ConwayEra -> C.UTxO C.ConwayEra -> TxSummary
+summarizeTx tx utxo =
+  let body = C.getTxBody tx
+      C.TxBody content = body
+      txId = C.getTxId body
+      inputs = ... -- resolve from utxo
+      outputs = ... -- from txBodyContent
+      mint = ... -- from txMintValue content
+      fee = ... -- from txFee content
+      signers = ... -- from txExtraKeyWits content
+      validRange = ... -- from txValidityLowerBound/txValidityUpperBound
+  in TxSummary { ... }
+```
+
+## Streaming: Delivering Traces to the Extension
+
+### New Event Type
+
+Add to `Convex.Tasty.Streaming.Types`:
+
+```haskell
+data Event
+  = ...existing constructors...
+  | IterationTraceEvent
+      { iteTestId :: !Int
+      , iteIteration :: !IterationTrace  -- from Convex.TestingInterface.Trace
+      }
+```
+
+**However**, this creates a dependency from `convex-tasty-streaming` on `convex-testing-interface` which is undesirable (circular or heavyweight).
+
+### Better: Agnostic Serialized Blob
+
+Instead, the streaming layer treats iteration traces as opaque JSON `Value`:
+
+```haskell
+data Event
+  = ...existing constructors...
+  | TestTrace
+      { ettTestId :: !Int
+      , ettCategory :: !Text       -- "positive" | "negative"
+      , ettTrace :: !Value         -- pre-serialized JSON (the IterationTrace)
+      }
+```
+
+The `convex-tasty-streaming` package only needs `aeson` (already a dep). The `convex-testing-interface` package serializes `IterationTrace` to `Value` before storing.
+
+### Store & Recorder (in convex-tasty-streaming)
+
+Extend the existing TMStore pattern:
+
+```haskell
+-- In Convex.Tasty.Streaming.TMSummary (or new module Convex.Tasty.Streaming.TraceStore)
+
+newtype TraceStore = TraceStore (IORef (Map String [Value]))
+  -- Key: test path string, Value: list of serialized IterationTrace JSON values
+
+newtype TraceRecorder = TraceRecorder
+  { trRecordIteration :: String -> Value -> IO ()
+  }
+
+instance IsOption TraceRecorder where
+  defaultValue = TraceRecorder (\_ _ -> pure ())
+  optionName = Tagged "trace-recorder"
+  optionHelp = Tagged "internal: iteration trace recorder"
+
+newtype TraceStoreOption = TraceStoreOption (Maybe TraceStore)
+
+instance IsOption TraceStoreOption where
+  defaultValue = TraceStoreOption Nothing
+  optionName = Tagged "trace-store"
+  optionHelp = Tagged "internal: iteration trace store handle"
+```
+
+### Emission Strategy
+
+Two options (implement the pragmatic one first):
+
+**Option A: Emit after each iteration (real-time).**
+The testing-interface code calls `trRecordIteration` after each QuickCheck iteration. The recorder immediately emits an NDJSON line:
+
+```json
+{"event": "test_trace", "id": 3, "category": "positive", "iteration": {...}}
+```
+
+This gives the extension real-time updates as iterations complete.
+
+**Option B: Emit all at test_done time.**
+Store all iteration traces, then when the streaming reporter emits `test_done`, also emit all traces for that test. Simpler but no real-time feedback.
+
+**Recommendation: Option A** — real-time is much better for the VS Code UX (user sees iterations appearing live).
+
+### Implementation in convex-tasty-streaming
+
+The `TraceRecorder` directly emits (it holds a reference to the output lock):
+
+```haskell
+-- In Convex.Tasty.Streaming (the reporter module)
+
+-- When setting up the streaming reporter:
+let traceRecorder = TraceRecorder $ \key iterationJson -> do
+      -- Find the test ID for this key
+      let testId = lookupTestIdByKey testMap key
+      withMVar outputLock $ \_ ->
+        emitEvent $ TestTrace
+          { ettTestId = testId
+          , ettCategory = -- determined from key
+          , ettTrace = iterationJson
+          }
+```
+
+But wait — the test body doesn't know the Tasty test ID. The recorder needs to map test keys to IDs.
+
+**Solution:** The recorder is constructed by the reporter (which has the test map). The test body uses a logical key (like "MyContract/Positive tests"), and the recorder resolves it to the numeric ID.
+
+### Wiring in defaultMainStreaming
+
+```haskell
+defaultMainStreaming :: TestTree -> IO ()
+defaultMainStreaming tree = do
+  tmStore <- newTMStore
+  traceStore <- newTraceStore  -- NEW
+  outputLock <- newMVar ()     -- shared lock
+  let traceRec = streamingTraceRecorder traceStore outputLock  -- NEW
+  let tree' =
+        localOption (TMStoreOption (Just tmStore)) $
+          localOption (storeRecorder tmStore) $
+            localOption (TraceStoreOption (Just traceStore)) $  -- NEW
+              localOption traceRec $                              -- NEW
+                tree
+  defaultMainWithIngredients streamingIngredients tree'
+```
+
+### How the Testing Interface Gets the Recorder
+
+In `propRunActionsWithOptions`, access the recorder via Tasty's `askOption`:
+
+```haskell
+-- The test property needs access to the TraceRecorder.
+-- Tasty options are available in the test tree construction.
+-- We use `askOption` pattern:
+
+positiveTest :: ... -> TraceRecorder -> Property
+positiveTest opts traceRecorder tms evs = monadicIO $ do
+  ...
+  -- After building IterationTrace:
+  liftIO $ trRecordIteration traceRecorder testKey (toJSON iterTrace)
+```
+
+The `propRunActionsWithOptions` function uses `askOption` to retrieve the `TraceRecorder`:
+
+```haskell
+propRunActionsWithOptions groupName opts =
+  askOption $ \(traceRecorder :: TraceRecorder) ->
+    ... existing test tree construction, passing traceRecorder to positiveTest ...
+```
+
+## File Structure (New/Modified Files)
+
+### New Files
+
+| File | Package | Purpose |
+|------|---------|---------|
+| `src/testing-interface/lib/Convex/TestingInterface/Trace.hs` | convex-testing-interface | Data types + ToJSON instances |
+| `src/testing-interface/lib/Convex/TestingInterface/Trace/TxSummary.hs` | convex-testing-interface | TxSummary builder (summarizeTx) |
+| `src/tasty-streaming/lib/Convex/Tasty/Streaming/TraceStore.hs` | convex-tasty-streaming | TraceStore, TraceRecorder, TraceStoreOption |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `src/testing-interface/lib/Convex/TestingInterface.hs` | Add `ToJSON state` constraint, create `runActionsTraced`, modify `positiveTest`/`negativeTest` to build and record traces, accept `TraceRecorder` |
+| `src/testing-interface/lib/Convex/ThreatModel.hs` | Add `runThreatModelCheckTraced` alongside existing `runThreatModelCheck` |
+| `src/testing-interface/convex-testing-interface.cabal` | Add new exposed modules, add `aeson` dep (already there) |
+| `src/tasty-streaming/lib/Convex/Tasty/Streaming.hs` | Wire TraceStore/TraceRecorder, emit `test_trace` events |
+| `src/tasty-streaming/lib/Convex/Tasty/Streaming/Types.hs` | Add `TestTrace` constructor to `Event` |
+| `src/tasty-streaming/convex-tasty-streaming.cabal` | Add new exposed module |
+
+## Implementation Order
+
+1. **Phase 1: Data types** — Create `Convex.TestingInterface.Trace` with all types and ToJSON instances. No behavioral changes yet. Compiles independently.
+
+2. **Phase 2: TxSummary builder** — Create `summarizeTx` and helpers. Test with a simple unit test that builds a tx and summarizes it.
+
+3. **Phase 3: Traced runner** — Create `runActionsTraced` and `runThreatModelCheckTraced`. These are NEW functions alongside the existing ones (no breaking changes to existing behavior).
+
+4. **Phase 4: Wire into positiveTest/negativeTest** — Modify the test property functions to use traced variants and build `IterationTrace`. Pass `TraceRecorder` through.
+
+5. **Phase 5: TraceStore + streaming** — Create `TraceStore` module, extend Event type, wire into `defaultMainStreaming`.
+
+6. **Phase 6: Integration test** — Run an existing test suite with `--streaming-json` and verify the new `test_trace` events appear with correct structure.
+
+## Design Principles
+
+1. **User sees no change** except adding `ToJSON` to their state type. All recording is internal to the framework.
+2. **Existing behavior preserved** — `runActions` still exists unchanged. The traced variant is used only when a `TraceRecorder` is active (not no-op default).
+3. **Delivery-agnostic data** — The `Trace` types know nothing about streaming, stdout, or VS Code. They're just data with JSON serialization.
+4. **No spaghetti** — Each concern is in its own module. The data types are in `Trace.hs`, the tx summarization in `TxSummary.hs`, the store in `TraceStore.hs`, the recording in the framework's existing control flow.
+5. **Performance guard** — When `TraceRecorder` is the default no-op, zero overhead (no JSON serialization happens). The `toJSON` calls only execute when streaming is active.
+
+## Key Decisions Made
+
+- **Threat models are nested in positive iterations** — because they reuse the same transactions. No separate iteration concept for threat models.
+- **`ToJSON state` required** — structured data is essential for the extension to render diffs and tables.
+- **Real-time emission** — traces are emitted per-iteration as they complete, not batched at test end.
+- **Opaque `Value` in streaming layer** — `convex-tasty-streaming` doesn't depend on `convex-testing-interface`; it just passes pre-serialized JSON.
+- **`test_trace` is a new event type** — keeps backward compatibility (old consumers ignore unknown events).
+
+## JSON Event Stream Example (Full)
+
+A complete streaming session would look like:
+
+```
+{"event":"suite_started","tests":[{"id":1,"name":"Positive tests","path":["MyContract","Positive tests"]},{"id":2,"name":"Negative tests","path":["MyContract","Negative tests"]},{"id":3,"name":"unprotectedScriptOutput","path":["MyContract","Threat models","unprotectedScriptOutput"]}]}
+{"event":"test_started","id":1}
+{"event":"test_trace","id":1,"category":"positive","iteration":{"index":0,"seed":42,"status":"success","transitions":[...],"threatModels":[...]}}
+{"event":"test_trace","id":1,"category":"positive","iteration":{"index":1,"seed":43,"status":"success","transitions":[...],"threatModels":[...]}}
+... (100 iterations) ...
+{"event":"test_done","id":1,"success":true,"duration":5.2,"description":"OK, passed 100 tests"}
+{"event":"test_started","id":2}
+{"event":"test_trace","id":2,"category":"negative","iteration":{"index":0,"seed":44,"status":"success","transitions":[...],"threatModels":[]}}
+... 
+{"event":"test_done","id":2,"success":true,"duration":3.1,"description":"OK, passed 100 tests"}
+{"event":"test_started","id":3}
+{"event":"test_done","id":3,"success":true,"duration":0.01,"description":"Passed (147 tested, 147 passed)","threat_model":{"name":"unprotectedScriptOutput","tested":147,"total":147,"passed":147,"failed":0,"skipped":0,"errors":0}}
+{"event":"suite_done","passed":3,"failed":0,"duration":8.4}
+```
+
+## Negative Test Trace Shape
+
+For negative tests, the trace shows:
+- The valid prefix (transitions that succeeded)
+- The invalid action attempt (last transition with `TransitionFailure`)
+
+```json
+{
+  "index": 5,
+  "seed": 99,
+  "status": "success",
+  "transitions": [
+    {"stepIndex": 0, "action": "Deposit w1 50₳", "stateBefore": {...}, "stateAfter": {...}, "transaction": {...}, "result": {"status": "success", "txId": "..."}},
+    {"stepIndex": 1, "action": "Deposit w2 30₳", "stateBefore": {...}, "stateAfter": {...}, "transaction": {...}, "result": {"status": "success", "txId": "..."}},
+    {"stepIndex": 2, "action": "Withdraw w1 200₳ [INVALID - violates precondition]", "stateBefore": {...}, "stateAfter": {...}, "transaction": null, "result": {"status": "failure", "error": "InsufficientFunds ..."}}
+  ],
+  "threatModels": []
+}
+```
+
+## Edge Cases to Handle
+
+1. **perform succeeds but submits no tx** (e.g., off-chain state update only) → `trTransaction = Nothing`, `trResult = TransitionSuccess ""`
+2. **perform submits multiple txs** (rare but possible) → capture only the last one, or extend to list (start with last-only for simplicity)
+3. **Threat model tests multiple envs** (iterates through txs) → one `ThreatModelTrace` entry per env tested, or aggregate. Start with per-env for maximum visibility.
+4. **Large state types** → The JSON could be large. Consider adding a max-size guard or truncation in the streaming layer (future optimization).
+5. **QuickCheck seed** → Available via `replay` option or by capturing it from the QC internals. May need to use `withMaxSuccess` + explicit seed tracking.
+
+## Dependencies (Package Changes)
+
+### convex-testing-interface.cabal additions:
+```
+exposed-modules:
+  ...existing...
+  Convex.TestingInterface.Trace
+  Convex.TestingInterface.Trace.TxSummary
+```
+No new package dependencies needed (already has `aeson`, `cardano-api`, `text`, `containers`).
+
+### convex-tasty-streaming.cabal additions:
+```
+exposed-modules:
+  ...existing...
+  Convex.Tasty.Streaming.TraceStore
+```
+No new package dependencies needed (already has `aeson`, `containers`).

--- a/cabal.project.schema-gen
+++ b/cabal.project.schema-gen
@@ -1,0 +1,14 @@
+-- cabal.project.schema-gen
+-- Separate project file for schema generation tool.
+-- Kept out of the main cabal.project to avoid pulling openapi3 into the
+-- Nix build (haskell.nix builds every package listed in cabal.project).
+--
+-- Usage:
+--   cabal build --project-file=cabal.project.schema-gen gen-schema
+--   cabal run   --project-file=cabal.project.schema-gen gen-schema \
+--     > src/tasty-streaming/schema/streaming-events.schema.json
+
+import: cabal.project
+
+packages:
+  src/schema-gen

--- a/src/schema-gen/app/Main.hs
+++ b/src/schema-gen/app/Main.hs
@@ -1,0 +1,9 @@
+module Main where
+
+import Data.Aeson.Encode.Pretty (encodePretty)
+import Data.ByteString.Lazy.Char8 qualified as BL
+
+import Convex.SchemaGen (streamingEventSchema)
+
+main :: IO ()
+main = BL.putStrLn $ encodePretty streamingEventSchema

--- a/src/schema-gen/convex-schema-gen.cabal
+++ b/src/schema-gen/convex-schema-gen.cabal
@@ -1,0 +1,42 @@
+cabal-version: 3.0
+name:          convex-schema-gen
+version:       0.1.0.0
+synopsis:      JSON Schema generator for sc-tools streaming events
+license:       Apache-2.0
+build-type:    Simple
+
+common lang
+  default-language:   Haskell2010
+  default-extensions:
+    DeriveGeneric
+    DerivingStrategies
+    GADTs
+    ImportQualifiedPost
+    NamedFieldPuns
+    OverloadedStrings
+    ScopedTypeVariables
+    TypeApplications
+
+library
+  import:          lang
+  hs-source-dirs:  lib
+  exposed-modules: Convex.SchemaGen
+  build-depends:
+    , aeson
+    , base                       >=4.14.0
+    , convex-tasty-streaming
+    , convex-testing-interface
+    , insert-ordered-containers
+    , lens
+    , openapi3                   >=3.2    && <3.3
+    , text
+
+executable gen-schema
+  import:         lang
+  hs-source-dirs: app
+  main-is:        Main.hs
+  build-depends:
+    , aeson-pretty
+    , base               >=4.14.0
+    , bytestring
+    , convex-schema-gen

--- a/src/schema-gen/lib/Convex/SchemaGen.hs
+++ b/src/schema-gen/lib/Convex/SchemaGen.hs
@@ -1,0 +1,694 @@
+{-# LANGUAGE DataKinds #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Convex.SchemaGen (
+  -- * Schema generation
+  streamingEventSchema,
+) where
+
+import Control.Lens hiding (allOf, (.=))
+import Data.Aeson ((.=))
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.HashMap.Strict.InsOrd qualified as InsOrdHashMap
+import Data.OpenApi
+import Data.OpenApi.Declare
+import Data.OpenApi.Lens qualified as L
+import Data.Proxy (Proxy (..))
+import Data.Text (Text)
+import Data.Text qualified as Text
+
+-- Types from convex-tasty-streaming
+import Convex.Tasty.Streaming.TMSummary (ThreatModelSummary (..))
+import Convex.Tasty.Streaming.Types (Event (..), FailureInfo (..), TestInfo (..), TestOutcome (..))
+
+-- Types from convex-testing-interface
+import Convex.TestingInterface.Trace (
+  AssetSummary (..),
+  IterationStatus (..),
+  IterationTrace (..),
+  TestCategory (..),
+  TestRunTrace (..),
+  ThreatModelTrace (..),
+  ThreatModelTraceOutcome (..),
+  Transition (..),
+  TransitionResult (..),
+  TxInputSummary (..),
+  TxOutputSummary (..),
+  TxSummary (..),
+  ValueSummary (..),
+ )
+import Convex.ThreatModel.TxModifier (TxMod (..))
+
+{- | The complete schema for a single NDJSON streaming event line.
+This is the root schema — each line of output is one Event.
+-}
+streamingEventSchema :: Aeson.Value
+streamingEventSchema =
+  let (defs, _eventRef) = runDeclare (declareSchemaRef (Proxy @Event)) (mempty :: Definitions Schema)
+      -- Serialize all definitions to JSON and fix $ref paths
+      defsJson = fmap (fixRefs . Aeson.toJSON) defs
+      -- Get the Event schema to extract its oneOf for root level
+      eventSchema = case InsOrdHashMap.lookup "Event" defs of
+        Just s -> fixRefs (Aeson.toJSON s)
+        Nothing -> Aeson.object []
+      -- Extract oneOf from Event schema for the root
+      rootOneOf = case eventSchema of
+        Aeson.Object o -> case KeyMap.lookup "oneOf" o of
+          Just v -> v
+          Nothing -> Aeson.Array mempty
+        _ -> Aeson.Array mempty
+   in Aeson.object
+        [ "$schema" .= ("https://json-schema.org/draft/2020-12/schema" :: Text)
+        , "$id" .= ("https://github.com/j-mueller/sc-tools/streaming-events.schema.json" :: Text)
+        , "title" .= ("SC-Tools Streaming Event" :: Text)
+        , "description" .= ("A single NDJSON line from the sc-tools test streaming reporter" :: Text)
+        , "oneOf" .= rootOneOf
+        , "$defs" .= InsOrdHashMap.toHashMap defsJson
+        ]
+
+-- | Recursively replace "#/components/schemas/" with "#/$defs/" in all $ref values
+fixRefs :: Aeson.Value -> Aeson.Value
+fixRefs (Aeson.Object o) = Aeson.Object $
+  KeyMap.map fixRefs $
+    case KeyMap.lookup "$ref" o of
+      Just (Aeson.String ref) ->
+        KeyMap.insert "$ref" (Aeson.String (Text.replace "#/components/schemas/" "#/$defs/" ref)) o
+      _ -> o
+fixRefs (Aeson.Array a) = Aeson.Array $ fmap fixRefs a
+fixRefs v = v
+
+-- ============================================================
+-- ToSchema instances for convex-tasty-streaming types
+-- ============================================================
+
+instance ToSchema TestInfo where
+  declareNamedSchema _ = do
+    pure $
+      NamedSchema (Just "TestInfo") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ InsOrdHashMap.fromList
+              [ ("id", Inline $ mempty & type_ ?~ OpenApiInteger)
+              , ("name", Inline $ mempty & type_ ?~ OpenApiString)
+              , ("path", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject (Inline $ mempty & type_ ?~ OpenApiString))
+              ]
+          & required .~ ["id", "name", "path"]
+
+instance ToSchema FailureInfo where
+  declareNamedSchema _ = do
+    pure $
+      NamedSchema (Just "FailureInfo") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ InsOrdHashMap.fromList
+              [ ("reason", Inline $ mempty & type_ ?~ OpenApiString)
+              , ("message", Inline $ mempty & type_ ?~ OpenApiString)
+              ]
+          & required .~ ["reason", "message"]
+
+instance ToSchema ThreatModelSummary where
+  declareNamedSchema _ = do
+    pure $
+      NamedSchema (Just "ThreatModelSummary") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ InsOrdHashMap.fromList
+              [ ("name", Inline $ mempty & type_ ?~ OpenApiString)
+              , ("tested", Inline $ mempty & type_ ?~ OpenApiInteger)
+              , ("total", Inline $ mempty & type_ ?~ OpenApiInteger)
+              , ("passed", Inline $ mempty & type_ ?~ OpenApiInteger)
+              , ("failed", Inline $ mempty & type_ ?~ OpenApiInteger)
+              , ("skipped", Inline $ mempty & type_ ?~ OpenApiInteger)
+              , ("errors", Inline $ mempty & type_ ?~ OpenApiInteger)
+              ]
+          & required .~ ["name", "tested", "total", "passed", "failed", "skipped", "errors"]
+
+instance ToSchema Event where
+  declareNamedSchema _ = do
+    testInfoRef <- declareSchemaRef (Proxy @TestInfo)
+    failureInfoRef <- declareSchemaRef (Proxy @FailureInfo)
+    threatModelSummaryRef <- declareSchemaRef (Proxy @ThreatModelSummary)
+    iterationTraceRef <- declareSchemaRef (Proxy @IterationTrace)
+
+    let suiteStarted =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("event", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["suite_started"])
+                , ("tests", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject testInfoRef)
+                ]
+            & required .~ ["event", "tests"]
+
+    let testStarted =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("event", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["test_started"])
+                , ("id", Inline $ mempty & type_ ?~ OpenApiInteger)
+                ]
+            & required .~ ["event", "id"]
+
+    let testProgress =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("event", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["test_progress"])
+                , ("id", Inline $ mempty & type_ ?~ OpenApiInteger)
+                , ("message", Inline $ mempty & type_ ?~ OpenApiString)
+                , ("percent", Inline $ mempty & type_ ?~ OpenApiNumber & format ?~ "float")
+                ]
+            & required .~ ["event", "id", "message", "percent"]
+
+    -- TestDone is complex: TestOutcome is inlined (success: bool + optional failure)
+    -- threat_model is optional (key absent when Nothing)
+    let testDone =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("event", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["test_done"])
+                , ("id", Inline $ mempty & type_ ?~ OpenApiInteger)
+                , ("duration", Inline $ mempty & type_ ?~ OpenApiNumber & format ?~ "double")
+                , ("description", Inline $ mempty & type_ ?~ OpenApiString)
+                , ("success", Inline $ mempty & type_ ?~ OpenApiBoolean)
+                , ("failure", failureInfoRef) -- optional, absent when success=true
+                , ("threat_model", threatModelSummaryRef) -- optional, absent when not applicable
+                ]
+            & required .~ ["event", "id", "duration", "description", "success"]
+
+    -- TestTrace: trace is Value (pre-serialized IterationTrace)
+    let testTrace =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("event", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["test_trace"])
+                , ("id", Inline $ mempty & type_ ?~ OpenApiInteger)
+                , ("category", Inline $ mempty & type_ ?~ OpenApiString)
+                , ("trace", iterationTraceRef) -- pre-serialized but matches IterationTrace schema
+                ]
+            & required .~ ["event", "id", "category", "trace"]
+
+    let suiteDone =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("event", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["suite_done"])
+                , ("passed", Inline $ mempty & type_ ?~ OpenApiInteger)
+                , ("failed", Inline $ mempty & type_ ?~ OpenApiInteger)
+                , ("duration", Inline $ mempty & type_ ?~ OpenApiNumber & format ?~ "double")
+                ]
+            & required .~ ["event", "passed", "failed", "duration"]
+
+    pure $
+      NamedSchema (Just "Event") $
+        mempty
+          & oneOf ?~ [Inline suiteStarted, Inline testStarted, Inline testProgress, Inline testDone, Inline testTrace, Inline suiteDone]
+          & discriminator ?~ Discriminator "event" mempty
+
+-- ============================================================
+-- ToSchema instances for convex-testing-interface types
+-- ============================================================
+
+instance ToSchema AssetSummary where
+  declareNamedSchema _ = do
+    pure $
+      NamedSchema (Just "AssetSummary") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ InsOrdHashMap.fromList
+              [ ("policyId", Inline $ mempty & type_ ?~ OpenApiString)
+              , ("name", Inline $ mempty & type_ ?~ OpenApiString)
+              , ("quantity", Inline $ mempty & type_ ?~ OpenApiInteger)
+              ]
+          & required .~ ["policyId", "name", "quantity"]
+
+instance ToSchema ValueSummary where
+  declareNamedSchema _ = do
+    assetRef <- declareSchemaRef (Proxy @AssetSummary)
+    pure $
+      NamedSchema (Just "ValueSummary") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ InsOrdHashMap.fromList
+              [ ("lovelace", Inline $ mempty & type_ ?~ OpenApiInteger)
+              , ("assets", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject assetRef)
+              ]
+          & required .~ ["lovelace", "assets"]
+
+instance ToSchema TxInputSummary where
+  declareNamedSchema _ = do
+    valueRef <- declareSchemaRef (Proxy @ValueSummary)
+    pure $
+      NamedSchema (Just "TxInputSummary") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ InsOrdHashMap.fromList
+              [ ("utxo", Inline $ mempty & type_ ?~ OpenApiString)
+              , ("address", Inline $ mempty & type_ ?~ OpenApiString)
+              , ("value", valueRef)
+              ]
+          & required .~ ["utxo", "address", "value"]
+
+instance ToSchema TxOutputSummary where
+  declareNamedSchema _ = do
+    valueRef <- declareSchemaRef (Proxy @ValueSummary)
+    pure $
+      NamedSchema (Just "TxOutputSummary") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ InsOrdHashMap.fromList
+              [ ("utxo", Inline $ mempty & type_ ?~ OpenApiString)
+              , ("address", Inline $ mempty & type_ ?~ OpenApiString)
+              , ("value", valueRef)
+              , ("datum", Inline $ mempty & type_ ?~ OpenApiString & nullable ?~ True) -- key present, value null when no datum
+              ]
+          & required .~ ["utxo", "address", "value", "datum"]
+
+instance ToSchema TxSummary where
+  declareNamedSchema _ = do
+    inputRef <- declareSchemaRef (Proxy @TxInputSummary)
+    outputRef <- declareSchemaRef (Proxy @TxOutputSummary)
+    valueRef <- declareSchemaRef (Proxy @ValueSummary)
+    pure $
+      NamedSchema (Just "TxSummary") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ InsOrdHashMap.fromList
+              [ ("id", Inline $ mempty & type_ ?~ OpenApiString & nullable ?~ True)
+              , ("inputs", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject inputRef)
+              , ("outputs", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject outputRef)
+              , ("mint", Inline $ mempty & nullable ?~ True & allOf ?~ [valueRef]) -- nullable ref
+              , ("fee", Inline $ mempty & type_ ?~ OpenApiInteger)
+              , ("signers", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject (Inline $ mempty & type_ ?~ OpenApiString))
+              , ("validRange", Inline $ mempty & type_ ?~ OpenApiString & nullable ?~ True)
+              ]
+          & required .~ ["id", "inputs", "outputs", "mint", "fee", "signers", "validRange"]
+
+instance ToSchema TransitionResult where
+  declareNamedSchema _ = do
+    let success =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("status", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["success"])
+                , ("txId", Inline $ mempty & type_ ?~ OpenApiString)
+                ]
+            & required .~ ["status", "txId"]
+    let failure =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("status", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["failure"])
+                , ("error", Inline $ mempty & type_ ?~ OpenApiString)
+                ]
+            & required .~ ["status", "error"]
+    pure $
+      NamedSchema (Just "TransitionResult") $
+        mempty
+          & oneOf ?~ [Inline success, Inline failure]
+          & discriminator ?~ Discriminator "status" mempty
+
+instance ToSchema Transition where
+  declareNamedSchema _ = do
+    txRef <- declareSchemaRef (Proxy @TxSummary)
+    resultRef <- declareSchemaRef (Proxy @TransitionResult)
+    pure $
+      NamedSchema (Just "Transition") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ InsOrdHashMap.fromList
+              [ ("stepIndex", Inline $ mempty & type_ ?~ OpenApiInteger)
+              , ("action", Inline $ mempty & type_ ?~ OpenApiString)
+              , ("stateBefore", Inline mempty) -- opaque JSON (user model state)
+              , ("stateAfter", Inline mempty) -- opaque JSON (user model state)
+              , ("transaction", Inline $ mempty & nullable ?~ True & allOf ?~ [txRef]) -- nullable ref
+              , ("result", resultRef)
+              ]
+          & required .~ ["stepIndex", "action", "stateBefore", "stateAfter", "transaction", "result"]
+
+instance ToSchema IterationStatus where
+  declareNamedSchema _ = do
+    let success =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [("status", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["success"])]
+            & required .~ ["status"]
+    let failure =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("status", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["failure"])
+                , ("message", Inline $ mempty & type_ ?~ OpenApiString)
+                ]
+            & required .~ ["status", "message"]
+    let discarded =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("status", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["discarded"])
+                , ("message", Inline $ mempty & type_ ?~ OpenApiString)
+                ]
+            & required .~ ["status", "message"]
+    pure $
+      NamedSchema (Just "IterationStatus") $
+        mempty
+          & oneOf ?~ [Inline success, Inline failure, Inline discarded]
+          & discriminator ?~ Discriminator "status" mempty
+
+instance ToSchema ThreatModelTraceOutcome where
+  declareNamedSchema _ = do
+    let passed =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [("status", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["passed"])]
+            & required .~ ["status"]
+    let failed =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("status", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["failed"])
+                , ("reason", Inline $ mempty & type_ ?~ OpenApiString)
+                ]
+            & required .~ ["status", "reason"]
+    let skipped =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("status", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["skipped"])
+                , ("reason", Inline $ mempty & type_ ?~ OpenApiString)
+                ]
+            & required .~ ["status", "reason"]
+    let err =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("status", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["error"])
+                , ("message", Inline $ mempty & type_ ?~ OpenApiString)
+                ]
+            & required .~ ["status", "message"]
+    pure $
+      NamedSchema (Just "ThreatModelTraceOutcome") $
+        mempty
+          & oneOf ?~ [Inline passed, Inline failed, Inline skipped, Inline err]
+          & discriminator ?~ Discriminator "status" mempty
+
+instance ToSchema TxMod where
+  declareNamedSchema _ = do
+    valueRef <- declareSchemaRef (Proxy @ValueSummary)
+    let nullableString = Inline $ mempty & type_ ?~ OpenApiString & nullable ?~ True
+    let nullableValue = Inline $ mempty & nullable ?~ True & allOf ?~ [valueRef]
+
+    let removeInput =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("type", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["removeInput"])
+                , ("utxo", Inline $ mempty & type_ ?~ OpenApiString)
+                ]
+            & required .~ ["type", "utxo"]
+
+    let removeOutput =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("type", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["removeOutput"])
+                , ("index", Inline $ mempty & type_ ?~ OpenApiInteger)
+                ]
+            & required .~ ["type", "index"]
+
+    let changeOutput =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("type", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["changeOutput"])
+                , ("index", Inline $ mempty & type_ ?~ OpenApiInteger)
+                , ("address", nullableString)
+                , ("value", nullableValue)
+                , ("datum", nullableString)
+                , ("referenceScript", nullableString)
+                ]
+            & required .~ ["type", "index", "address", "value", "datum", "referenceScript"]
+
+    let changeInput =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("type", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["changeInput"])
+                , ("utxo", Inline $ mempty & type_ ?~ OpenApiString)
+                , ("address", nullableString)
+                , ("value", nullableValue)
+                , ("datum", nullableString)
+                , ("referenceScript", nullableString)
+                ]
+            & required .~ ["type", "utxo", "address", "value", "datum", "referenceScript"]
+
+    let changeScriptInput =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("type", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["changeScriptInput"])
+                , ("utxo", Inline $ mempty & type_ ?~ OpenApiString)
+                , ("value", nullableValue)
+                , ("datum", nullableString)
+                , ("redeemer", nullableString)
+                , ("referenceScript", nullableString)
+                ]
+            & required .~ ["type", "utxo", "value", "datum", "redeemer", "referenceScript"]
+
+    let changeValidityRange =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("type", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["changeValidityRange"])
+                , ("lowerBound", nullableString)
+                , ("upperBound", nullableString)
+                ]
+            & required .~ ["type", "lowerBound", "upperBound"]
+
+    let addOutput =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("type", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["addOutput"])
+                , ("address", Inline $ mempty & type_ ?~ OpenApiString)
+                , ("value", valueRef)
+                , ("datum", nullableString)
+                , ("referenceScript", Inline $ mempty & type_ ?~ OpenApiString)
+                ]
+            & required .~ ["type", "address", "value", "datum", "referenceScript"]
+
+    let addInput =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("type", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["addInput"])
+                , ("address", Inline $ mempty & type_ ?~ OpenApiString)
+                , ("value", valueRef)
+                , ("datum", nullableString)
+                , ("referenceScript", Inline $ mempty & type_ ?~ OpenApiString)
+                , ("isReferenceInput", Inline $ mempty & type_ ?~ OpenApiBoolean)
+                ]
+            & required .~ ["type", "address", "value", "datum", "referenceScript", "isReferenceInput"]
+
+    let addReferenceScriptInput =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("type", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["addReferenceScriptInput"])
+                , ("scriptHash", Inline $ mempty & type_ ?~ OpenApiString)
+                , ("value", valueRef)
+                , ("datum", nullableString)
+                , ("redeemer", Inline $ mempty & type_ ?~ OpenApiString)
+                ]
+            & required .~ ["type", "scriptHash", "value", "datum", "redeemer"]
+
+    let addPlutusScriptInput =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("type", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["addPlutusScriptInput"])
+                , ("value", valueRef)
+                , ("datum", nullableString)
+                , ("redeemer", Inline $ mempty & type_ ?~ OpenApiString)
+                , ("referenceScript", Inline $ mempty & type_ ?~ OpenApiString)
+                ]
+            & required .~ ["type", "value", "datum", "redeemer", "referenceScript"]
+
+    let addPlutusScriptReferenceInput =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("type", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["addPlutusScriptReferenceInput"])
+                , ("value", valueRef)
+                , ("datum", nullableString)
+                , ("referenceScript", Inline $ mempty & type_ ?~ OpenApiString)
+                ]
+            & required .~ ["type", "value", "datum", "referenceScript"]
+
+    let addSimpleScriptInput =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("type", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["addSimpleScriptInput"])
+                , ("value", valueRef)
+                , ("referenceScript", Inline $ mempty & type_ ?~ OpenApiString)
+                , ("isReferenceInput", Inline $ mempty & type_ ?~ OpenApiBoolean)
+                ]
+            & required .~ ["type", "value", "referenceScript", "isReferenceInput"]
+
+    let addPlutusScriptMint =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("type", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["addPlutusScriptMint"])
+                , ("assetName", Inline $ mempty & type_ ?~ OpenApiString)
+                , ("quantity", Inline $ mempty & type_ ?~ OpenApiInteger)
+                , ("redeemer", Inline $ mempty & type_ ?~ OpenApiString)
+                ]
+            & required .~ ["type", "assetName", "quantity", "redeemer"]
+
+    let removeRequiredSigner =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [ ("type", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["removeRequiredSigner"])
+                , ("keyHash", Inline $ mempty & type_ ?~ OpenApiString)
+                ]
+            & required .~ ["type", "keyHash"]
+
+    let replaceTx =
+          mempty
+            & type_ ?~ OpenApiObject
+            & properties
+              .~ InsOrdHashMap.fromList
+                [("type", Inline $ mempty & type_ ?~ OpenApiString & enum_ ?~ ["replaceTx"])]
+            & required .~ ["type"]
+
+    pure $
+      NamedSchema (Just "TxMod") $
+        mempty
+          & oneOf
+            ?~ map
+              Inline
+              [ removeInput
+              , removeOutput
+              , changeOutput
+              , changeInput
+              , changeScriptInput
+              , changeValidityRange
+              , addOutput
+              , addInput
+              , addReferenceScriptInput
+              , addPlutusScriptInput
+              , addPlutusScriptReferenceInput
+              , addSimpleScriptInput
+              , addPlutusScriptMint
+              , removeRequiredSigner
+              , replaceTx
+              ]
+          & discriminator ?~ Discriminator "type" mempty
+
+instance ToSchema ThreatModelTrace where
+  declareNamedSchema _ = do
+    txRef <- declareSchemaRef (Proxy @TxSummary)
+    outcomeRef <- declareSchemaRef (Proxy @ThreatModelTraceOutcome)
+    txModRef <- declareSchemaRef (Proxy @TxMod)
+    pure $
+      NamedSchema (Just "ThreatModelTrace") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ InsOrdHashMap.fromList
+              [ ("name", Inline $ mempty & type_ ?~ OpenApiString)
+              , ("targetTxIndex", Inline $ mempty & type_ ?~ OpenApiInteger)
+              , ("modifications", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject txModRef)
+              , ("originalTx", txRef)
+              , ("modifiedTx", Inline $ mempty & nullable ?~ True & allOf ?~ [txRef])
+              , ("outcome", outcomeRef)
+              ]
+          & required .~ ["name", "targetTxIndex", "modifications", "originalTx", "modifiedTx", "outcome"]
+
+instance ToSchema IterationTrace where
+  declareNamedSchema _ = do
+    statusRef <- declareSchemaRef (Proxy @IterationStatus)
+    transitionRef <- declareSchemaRef (Proxy @Transition)
+    threatRef <- declareSchemaRef (Proxy @ThreatModelTrace)
+    pure $
+      NamedSchema (Just "IterationTrace") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ InsOrdHashMap.fromList
+              [ ("index", Inline $ mempty & type_ ?~ OpenApiInteger)
+              , ("status", statusRef)
+              , ("transitions", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject transitionRef)
+              , ("threatModels", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject threatRef)
+              ]
+          & required .~ ["index", "status", "transitions", "threatModels"]
+
+instance ToSchema TestCategory where
+  declareNamedSchema _ = do
+    pure $
+      NamedSchema (Just "TestCategory") $
+        mempty
+          & type_ ?~ OpenApiString
+          & enum_ ?~ ["positive", "negative"]
+
+instance ToSchema TestRunTrace where
+  declareNamedSchema _ = do
+    categoryRef <- declareSchemaRef (Proxy @TestCategory)
+    iterationRef <- declareSchemaRef (Proxy @IterationTrace)
+    pure $
+      NamedSchema (Just "TestRunTrace") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ InsOrdHashMap.fromList
+              [ ("testId", Inline $ mempty & type_ ?~ OpenApiInteger)
+              , ("testName", Inline $ mempty & type_ ?~ OpenApiString)
+              , ("path", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject (Inline $ mempty & type_ ?~ OpenApiString))
+              , ("category", categoryRef)
+              , ("iterations", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject iterationRef)
+              ]
+          & required .~ ["testId", "testName", "path", "category", "iterations"]

--- a/src/tasty-streaming/README.md
+++ b/src/tasty-streaming/README.md
@@ -215,6 +215,30 @@ cabal test convex-testing-interface-test \
   | jq -R 'fromjson? // empty | .tests[] | {id, name, path}'
 ```
 
+## JSON Schema
+
+A [JSON Schema (draft 2020-12)](https://json-schema.org/specification) describing every NDJSON event emitted by the streaming reporter lives at `schema/streaming-events.schema.json` in this package. Use it for VS Code extension type generation, payload validation, or as machine-readable documentation of the event format.
+
+### Regenerating the schema
+
+After modifying any `ToJSON` instance on streaming or trace types, regenerate the schema:
+
+```bash
+cabal run --project-file=cabal.project.schema-gen gen-schema \
+  > src/tasty-streaming/schema/streaming-events.schema.json
+```
+
+You need to regenerate whenever you change types in:
+
+- `Convex.TestingInterface.Trace`
+- `Convex.ThreatModel.TxModifier`
+- `Convex.Tasty.Streaming.Types`
+- `Convex.Tasty.Streaming.TMSummary`
+
+### How it works
+
+The `convex-schema-gen` package (in `src/schema-gen/`) defines `ToSchema` orphan instances (from `openapi3`) for all serialized types and converts them to JSON Schema. The `openapi3` dependency is quarantined in that package — it is never pulled into any library that users consume. A separate project file (`cabal.project.schema-gen`) includes `convex-schema-gen` without affecting the main Nix build.
+
 ## API Reference
 
 | Export                     | Type         | Description                                                          |

--- a/src/tasty-streaming/convex-tasty-streaming.cabal
+++ b/src/tasty-streaming/convex-tasty-streaming.cabal
@@ -39,6 +39,7 @@ library
   import:          lang
   exposed-modules:
     Convex.Tasty.Streaming
+    Convex.Tasty.Streaming.TMSummary
     Convex.Tasty.Streaming.TreeMap
     Convex.Tasty.Streaming.Types
 

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
@@ -8,6 +8,13 @@ module Convex.Tasty.Streaming (
 import Control.Concurrent.Async (forConcurrently_)
 import Control.Concurrent.MVar (newMVar, withMVar)
 import Control.Concurrent.STM
+import Convex.Tasty.Streaming.TMSummary (
+  TMRecorder,
+  TMStoreOption (..),
+  lookupThreatModelSummary,
+  newTMStore,
+  storeRecorder,
+ )
 import Convex.Tasty.Streaming.TreeMap (buildTestMap)
 import Convex.Tasty.Streaming.Types
 import Data.Aeson (encode)
@@ -18,13 +25,14 @@ import Data.Tagged (Tagged (..))
 import Data.Text qualified as Text
 import Data.Typeable (Typeable)
 import System.IO (BufferMode (..), hFlush, hSetBuffering, stdout)
-import Test.Tasty (TestTree, defaultMainWithIngredients)
+import Test.Tasty (TestTree, defaultMainWithIngredients, localOption)
 import Test.Tasty.Ingredients (Ingredient (..))
 import Test.Tasty.Ingredients.ConsoleReporter (consoleTestReporter)
 import Test.Tasty.Options (IsOption (..), OptionDescription (..), lookupOption, mkFlagCLParser, safeRead)
 import Test.Tasty.Runners (
   FailureReason (..),
   Outcome (..),
+  Progress (..),
   Result (..),
   Status (..),
   listingTests,
@@ -59,12 +67,16 @@ newline-delimited JSON events streamed to stdout.
 -}
 streamingJsonReporter :: Ingredient
 streamingJsonReporter = TestReporter
-  [Option (Proxy :: Proxy StreamingJson)]
+  [ Option (Proxy :: Proxy StreamingJson)
+  , Option (Proxy :: Proxy TMStoreOption)
+  , Option (Proxy :: Proxy TMRecorder)
+  ]
   $ \opts tree -> do
     let StreamingJson enabled = lookupOption opts
     if not enabled
       then Nothing
       else Just $ \statusMap -> do
+        let TMStoreOption mStore = lookupOption opts
         -- Set line buffering for streaming
         hSetBuffering stdout LineBuffering
 
@@ -94,27 +106,62 @@ streamingJsonReporter = TestReporter
           -- Emit test_started
           emit $ TestStarted idx
 
-          -- Wait for completion
-          result <- atomically $ do
-            status <- readTVar statusTVar
-            case status of
-              Done r -> pure r
-              _ -> retry
+          -- Wait for completion, emitting progress events along the way
+          let waitLoop lastSeen = do
+                next <- atomically $ do
+                  status <- readTVar statusTVar
+                  case status of
+                    NotStarted -> retry
+                    Executing p ->
+                      let cur = (progressText p, progressPercent p)
+                       in if Just cur == lastSeen
+                            then retry
+                            else pure (Left p)
+                    Done r -> pure (Right r)
+                case next of
+                  Left p -> do
+                    emit $
+                      TestProgress
+                        { epId = idx
+                        , epMessage = Text.pack (progressText p)
+                        , epPercent = progressPercent p
+                        }
+                    waitLoop (Just (progressText p, progressPercent p))
+                  Right r -> pure r
+          result <- waitLoop Nothing
 
           -- Record result
           atomically $ modifyTVar' resultsVar ((idx, result) :)
 
+          -- Look up structured threat-model summary by "<group>/<name>" key
+          let testInfo = IntMap.lookup idx testMap
+              key = case testInfo of
+                Just ti
+                  | (parent : _) <- reverse (tiPath ti) ->
+                      Text.unpack parent <> "/" <> Text.unpack (tiName ti)
+                Just ti -> Text.unpack (tiName ti)
+                Nothing -> ""
+          mSummary <- case mStore of
+            Just store -> lookupThreatModelSummary store key
+            Nothing -> pure Nothing
+
           -- Emit test_done
-          let testName = maybe "" tiName (IntMap.lookup idx testMap)
           let outcome = case resultOutcome result of
                 Success -> TestSuccess
                 Failure reason ->
                   TestFailure $
                     FailureInfo
                       { fiReason = Text.pack $ showFailureReason reason
-                      , fiMessage = Text.pack $ resultDescription result
+                      , fiMessage = Text.pack (resultDescription result)
                       }
-          emit $ TestDone idx outcome (resultTime result) testName
+          emit $
+            TestDone
+              { edId = idx
+              , edOutcome = outcome
+              , edDuration = resultTime result
+              , edDescription = Text.pack (resultDescription result)
+              , edThreatModel = mSummary
+              }
 
         -- Emit suite_done summary
         allResults <- readTVarIO resultsVar
@@ -167,6 +214,18 @@ listTestsJsonIngredient = TestManager
 streamingIngredients :: [Ingredient]
 streamingIngredients = [listingTests, listTestsJsonIngredient, streamingJsonReporter, consoleTestReporter]
 
--- | Drop-in replacement for 'defaultMain' that supports @--streaming-json@.
+{- | Drop-in replacement for 'defaultMain' that supports @--streaming-json@.
+
+If you bypass this entry point and wire 'streamingIngredients' manually,
+threat-model summaries will not appear in the JSON output unless you
+also call
+@'localOption' ('TMStoreOption' (Just store)) . 'localOption' ('storeRecorder' store)@
+on your tree (with a freshly-allocated store from 'newTMStore').
+-}
 defaultMainStreaming :: TestTree -> IO ()
-defaultMainStreaming = defaultMainWithIngredients streamingIngredients
+defaultMainStreaming tree = do
+  store <- newTMStore
+  let tree' =
+        localOption (TMStoreOption (Just store)) $
+          localOption (storeRecorder store) tree
+  defaultMainWithIngredients streamingIngredients tree'

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
@@ -6,7 +6,7 @@ module Convex.Tasty.Streaming (
 ) where
 
 import Control.Concurrent.Async (forConcurrently_)
-import Control.Concurrent.MVar (newMVar, withMVar)
+import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Concurrent.STM
 import Control.Monad (when)
 import Convex.Tasty.Streaming.TMSummary (
@@ -53,6 +53,17 @@ instance IsOption StreamingJson where
   optionHelp = Tagged "Enable streaming NDJSON test output to stdout"
   optionCLParser = mkFlagCLParser mempty (StreamingJson True)
 
+-- | Command-line option to disable iteration trace collection
+newtype NoTrace = NoTrace Bool
+  deriving (Eq, Ord, Typeable)
+
+instance IsOption NoTrace where
+  defaultValue = NoTrace False
+  parseValue = fmap NoTrace . safeRead
+  optionName = Tagged "no-trace"
+  optionHelp = Tagged "Disable iteration trace collection (only effective with --streaming-json)"
+  optionCLParser = mkFlagCLParser mempty (NoTrace True)
+
 -- | Command-line option to list tests as JSON without running them
 newtype ListTestsJson = ListTestsJson Bool
   deriving (Eq, Ord, Typeable)
@@ -76,6 +87,17 @@ instance IsOption StreamingEnabledRef where
   optionName = Tagged "streaming-enabled-ref"
   optionHelp = Tagged "internal: streaming enabled flag"
 
+{- | Internal option carrying a shared 'MVar ()' so the reporter and the
+'TraceRecorder' use the same output lock, preventing interleaved NDJSON lines.
+-}
+newtype OutputLockRef = OutputLockRef (Maybe (MVar ()))
+
+instance IsOption OutputLockRef where
+  defaultValue = OutputLockRef Nothing
+  parseValue = const Nothing
+  optionName = Tagged "output-lock-ref"
+  optionHelp = Tagged "internal: shared output lock"
+
 {- | Internal option carrying a shared 'IORef' so the reporter can publish the
 test map and the 'TraceRecorder' can read it back to resolve test IDs.
 -}
@@ -95,11 +117,13 @@ newline-delimited JSON events streamed to stdout.
 streamingJsonReporter :: Ingredient
 streamingJsonReporter = TestReporter
   [ Option (Proxy :: Proxy StreamingJson)
+  , Option (Proxy :: Proxy NoTrace)
   , Option (Proxy :: Proxy TMStoreOption)
   , Option (Proxy :: Proxy TMRecorder)
   , Option (Proxy :: Proxy TraceRecorder)
   , Option (Proxy :: Proxy TestMapRef)
   , Option (Proxy :: Proxy StreamingEnabledRef)
+  , Option (Proxy :: Proxy OutputLockRef)
   ]
   $ \opts tree -> do
     let StreamingJson enabled = lookupOption opts
@@ -112,15 +136,21 @@ streamingJsonReporter = TestReporter
 
         -- Signal that streaming is active so the TraceRecorder callback
         -- (which checks the same IORef) actually emits events.
+        -- When --no-trace is passed, leave the ref as False so that both
+        -- trEnabled and recordIteration remain no-ops.
+        let NoTrace noTrace = lookupOption opts
         case mEnabledRef of
-          Just ref -> writeIORef ref True
+          Just ref -> writeIORef ref (not noTrace)
           Nothing -> pure ()
 
         -- Set line buffering for streaming
         hSetBuffering stdout LineBuffering
 
-        -- Create lock for thread-safe output
-        outputLock <- newMVar ()
+        -- Use the shared output lock if provided, otherwise create a new one
+        -- (backward compatibility when the reporter is used without
+        -- defaultMainStreaming).
+        let OutputLockRef mSharedLock = lookupOption opts
+        outputLock <- maybe (newMVar ()) pure mSharedLock
         let emit evt = withMVar outputLock $ \_ -> emitEvent evt
 
         -- Build the test index -> metadata map
@@ -294,28 +324,26 @@ defaultMainStreaming tree = do
   store <- newTMStore
   testMapRef <- newIORef IntMap.empty
   enabledRef <- newIORef False -- set to True by the reporter when --streaming-json is active
+  -- Create a single shared output lock used by both the streaming reporter
+  -- and the TraceRecorder so their NDJSON lines never interleave.
+  outputLock <- newMVar ()
   -- Create a trace recorder that emits TestTrace events as NDJSON to stdout.
-  -- Uses its own lock for thread-safety; in practice single-line putStrLn calls
-  -- won't interleave with the reporter's own lock-protected output.
   -- The recorder reads the shared testMapRef (populated by the reporter at
   -- startup) to resolve the numeric Tasty test ID for each trace event.
   --
-  -- The callback checks 'enabledRef' before emitting anything, so when
-  -- --streaming-json is NOT passed, no NDJSON lines go to stdout.
-  -- 'trEnabled' is set True so that test bodies use the traced code path
-  -- (building IterationTrace values etc.) — a small overhead that is
-  -- acceptable when defaultMainStreaming is used. The actual emission is
-  -- still gated on the IORef.
-  traceLock <- newMVar ()
+  -- Both 'trEnabled' and 'recordIteration' read the shared 'enabledRef',
+  -- so when --streaming-json is NOT passed (or --no-trace is passed) the
+  -- ref stays False: test bodies take the fast path and no NDJSON lines
+  -- go to stdout.
   let traceRec =
         TraceRecorder
-          { trEnabled = True
+          { trEnabled = readIORef enabledRef
           , recordIteration = \group category iterationJson -> do
               enabled <- readIORef enabledRef
               when enabled $ do
                 testMap <- readIORef testMapRef
                 let testId = findTestId testMap group category
-                withMVar traceLock $ \_ ->
+                withMVar outputLock $ \_ ->
                   emitEvent $
                     TestTrace
                       { ettTestId = testId
@@ -328,5 +356,6 @@ defaultMainStreaming tree = do
           localOption (storeRecorder store) $
             localOption (TestMapRef (Just testMapRef)) $
               localOption (StreamingEnabledRef (Just enabledRef)) $
-                localOption traceRec tree
+                localOption (OutputLockRef (Just outputLock)) $
+                  localOption traceRec tree
   defaultMainWithIngredients streamingIngredients tree'

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
@@ -8,9 +8,11 @@ module Convex.Tasty.Streaming (
 import Control.Concurrent.Async (forConcurrently_)
 import Control.Concurrent.MVar (newMVar, withMVar)
 import Control.Concurrent.STM
+import Control.Monad (when)
 import Convex.Tasty.Streaming.TMSummary (
   TMRecorder,
   TMStoreOption (..),
+  TraceRecorder (..),
   lookupThreatModelSummary,
   newTMStore,
   storeRecorder,
@@ -19,6 +21,8 @@ import Convex.Tasty.Streaming.TreeMap (buildTestMap)
 import Convex.Tasty.Streaming.Types
 import Data.Aeson (encode)
 import Data.ByteString.Lazy.Char8 qualified as BL8
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.IntMap.Strict (IntMap)
 import Data.IntMap.Strict qualified as IntMap
 import Data.Proxy (Proxy (..))
 import Data.Tagged (Tagged (..))
@@ -60,6 +64,29 @@ instance IsOption ListTestsJson where
   optionHelp = Tagged "List all tests as a JSON object and exit without running"
   optionCLParser = mkFlagCLParser mempty (ListTestsJson True)
 
+{- | Internal option carrying a shared 'IORef Bool' that is set to 'True' by
+the streaming reporter when @--streaming-json@ is active.  The
+'TraceRecorder' callback checks this before emitting any events.
+-}
+newtype StreamingEnabledRef = StreamingEnabledRef (Maybe (IORef Bool))
+
+instance IsOption StreamingEnabledRef where
+  defaultValue = StreamingEnabledRef Nothing
+  parseValue = const Nothing
+  optionName = Tagged "streaming-enabled-ref"
+  optionHelp = Tagged "internal: streaming enabled flag"
+
+{- | Internal option carrying a shared 'IORef' so the reporter can publish the
+test map and the 'TraceRecorder' can read it back to resolve test IDs.
+-}
+newtype TestMapRef = TestMapRef (Maybe (IORef (IntMap TestInfo)))
+
+instance IsOption TestMapRef where
+  defaultValue = TestMapRef Nothing
+  parseValue = const Nothing
+  optionName = Tagged "test-map-ref"
+  optionHelp = Tagged "internal: shared test map reference"
+
 {- | The streaming JSON reporter ingredient.
 
 When activated via @--streaming-json@, replaces console output with
@@ -70,6 +97,9 @@ streamingJsonReporter = TestReporter
   [ Option (Proxy :: Proxy StreamingJson)
   , Option (Proxy :: Proxy TMStoreOption)
   , Option (Proxy :: Proxy TMRecorder)
+  , Option (Proxy :: Proxy TraceRecorder)
+  , Option (Proxy :: Proxy TestMapRef)
+  , Option (Proxy :: Proxy StreamingEnabledRef)
   ]
   $ \opts tree -> do
     let StreamingJson enabled = lookupOption opts
@@ -77,6 +107,15 @@ streamingJsonReporter = TestReporter
       then Nothing
       else Just $ \statusMap -> do
         let TMStoreOption mStore = lookupOption opts
+            TestMapRef mTestMapRef = lookupOption opts
+            StreamingEnabledRef mEnabledRef = lookupOption opts
+
+        -- Signal that streaming is active so the TraceRecorder callback
+        -- (which checks the same IORef) actually emits events.
+        case mEnabledRef of
+          Just ref -> writeIORef ref True
+          Nothing -> pure ()
+
         -- Set line buffering for streaming
         hSetBuffering stdout LineBuffering
 
@@ -86,6 +125,11 @@ streamingJsonReporter = TestReporter
 
         -- Build the test index -> metadata map
         testMap <- buildTestMap opts tree
+
+        -- Populate the shared test map ref so TraceRecorder can resolve IDs
+        case mTestMapRef of
+          Just ref -> writeIORef ref testMap
+          Nothing -> pure ()
 
         -- Emit suite_started with full test list
         let testInfos = map snd $ IntMap.toAscList testMap
@@ -192,6 +236,29 @@ showFailureReason (TestThrewException e) = "TestThrewException: " ++ show e
 showFailureReason (TestTimedOut n) = "TestTimedOut: " ++ show n ++ "μs"
 showFailureReason TestDepFailed = "TestDepFailed"
 
+{- | Find the Tasty test ID for a test identified by group name and category.
+Searches the test map for a 'TestInfo' whose path contains the group name
+and whose name matches the category (e.g. \"Positive tests\", \"Negative tests\").
+Returns @-1@ as a fallback when the test is not found.
+-}
+findTestId :: IntMap TestInfo -> String -> String -> Int
+findTestId testMap group category =
+  let categoryName = case category of
+        "positive" -> "Positive tests"
+        "negative" -> "Negative tests"
+        other -> other
+      matches =
+        IntMap.toList $
+          IntMap.filter
+            ( \ti ->
+                Text.pack group `elem` tiPath ti
+                  && tiName ti == Text.pack categoryName
+            )
+            testMap
+   in case matches of
+        ((testId, _) : _) -> testId
+        [] -> -1 -- fallback: test not found
+
 {- | Ingredient that lists the test tree as JSON and exits without running tests.
 
 Activated via @--list-tests-json@.
@@ -225,7 +292,41 @@ on your tree (with a freshly-allocated store from 'newTMStore').
 defaultMainStreaming :: TestTree -> IO ()
 defaultMainStreaming tree = do
   store <- newTMStore
+  testMapRef <- newIORef IntMap.empty
+  enabledRef <- newIORef False -- set to True by the reporter when --streaming-json is active
+  -- Create a trace recorder that emits TestTrace events as NDJSON to stdout.
+  -- Uses its own lock for thread-safety; in practice single-line putStrLn calls
+  -- won't interleave with the reporter's own lock-protected output.
+  -- The recorder reads the shared testMapRef (populated by the reporter at
+  -- startup) to resolve the numeric Tasty test ID for each trace event.
+  --
+  -- The callback checks 'enabledRef' before emitting anything, so when
+  -- --streaming-json is NOT passed, no NDJSON lines go to stdout.
+  -- 'trEnabled' is set True so that test bodies use the traced code path
+  -- (building IterationTrace values etc.) — a small overhead that is
+  -- acceptable when defaultMainStreaming is used. The actual emission is
+  -- still gated on the IORef.
+  traceLock <- newMVar ()
+  let traceRec =
+        TraceRecorder
+          { trEnabled = True
+          , recordIteration = \group category iterationJson -> do
+              enabled <- readIORef enabledRef
+              when enabled $ do
+                testMap <- readIORef testMapRef
+                let testId = findTestId testMap group category
+                withMVar traceLock $ \_ ->
+                  emitEvent $
+                    TestTrace
+                      { ettTestId = testId
+                      , ettCategory = Text.pack category
+                      , ettTrace = iterationJson
+                      }
+          }
   let tree' =
         localOption (TMStoreOption (Just store)) $
-          localOption (storeRecorder store) tree
+          localOption (storeRecorder store) $
+            localOption (TestMapRef (Just testMapRef)) $
+              localOption (StreamingEnabledRef (Just enabledRef)) $
+                localOption traceRec tree
   defaultMainWithIngredients streamingIngredients tree'

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming/TMSummary.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming/TMSummary.hs
@@ -6,12 +6,13 @@ module Convex.Tasty.Streaming.TMSummary (
   TMStore,
   TMRecorder (..),
   TMStoreOption (..),
+  TraceRecorder (..),
   newTMStore,
   storeRecorder,
   lookupThreatModelSummary,
 ) where
 
-import Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.=))
+import Data.Aeson (FromJSON (..), ToJSON (..), Value, object, withObject, (.:), (.=))
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -96,3 +97,25 @@ storeRecorder (TMStore ref) = TMRecorder $ \key s ->
 lookupThreatModelSummary :: TMStore -> String -> IO (Maybe ThreatModelSummary)
 lookupThreatModelSummary (TMStore ref) key =
   Map.lookup key <$> readIORef ref
+
+{- | Callback for recording iteration traces as pre-serialized JSON.
+Arguments: group name, category ("positive"\/"negative"), pre-serialized trace JSON.
+Default is a no-op (zero overhead when streaming is not active).
+
+When 'trEnabled' is 'True', test bodies use the expensive traced code path
+(building 'IterationTrace' values with UTxO snapshots, transaction
+summaries, and JSON serialisation).  When 'False' (the 'IsOption' default),
+the cheap 'runActions' path is used instead, avoiding all that work.
+-}
+data TraceRecorder = TraceRecorder
+  { trEnabled :: !Bool
+  -- ^ Whether test bodies should collect detailed traces.
+  , recordIteration :: String -> String -> Value -> IO ()
+  -- ^ Emit a single iteration trace event.
+  }
+
+instance IsOption TraceRecorder where
+  defaultValue = TraceRecorder False (\_ _ _ -> pure ())
+  parseValue = const Nothing
+  optionName = Tagged "trace-recorder"
+  optionHelp = Tagged "internal: iteration trace recorder"

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming/TMSummary.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming/TMSummary.hs
@@ -102,20 +102,24 @@ lookupThreatModelSummary (TMStore ref) key =
 Arguments: group name, category ("positive"\/"negative"), pre-serialized trace JSON.
 Default is a no-op (zero overhead when streaming is not active).
 
-When 'trEnabled' is 'True', test bodies use the expensive traced code path
-(building 'IterationTrace' values with UTxO snapshots, transaction
-summaries, and JSON serialisation).  When 'False' (the 'IsOption' default),
-the cheap 'runActions' path is used instead, avoiding all that work.
+When 'trEnabled' returns 'True', test bodies use the expensive traced code
+path (building 'IterationTrace' values with UTxO snapshots, transaction
+summaries, and JSON serialisation).  When it returns 'False' (the 'IsOption'
+default), the cheap 'runActions' path is used instead, avoiding all that
+work.
+
+'trEnabled' is an 'IO' action so that the decision can be deferred until the
+streaming reporter has parsed @--no-trace@ and written the shared 'IORef'.
 -}
 data TraceRecorder = TraceRecorder
-  { trEnabled :: !Bool
+  { trEnabled :: IO Bool
   -- ^ Whether test bodies should collect detailed traces.
   , recordIteration :: String -> String -> Value -> IO ()
   -- ^ Emit a single iteration trace event.
   }
 
 instance IsOption TraceRecorder where
-  defaultValue = TraceRecorder False (\_ _ _ -> pure ())
+  defaultValue = TraceRecorder (pure False) (\_ _ _ -> pure ())
   parseValue = const Nothing
   optionName = Tagged "trace-recorder"
   optionHelp = Tagged "internal: iteration trace recorder"

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming/TMSummary.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming/TMSummary.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Convex.Tasty.Streaming.TMSummary (
+  ThreatModelSummary (..),
+  TMStore,
+  TMRecorder (..),
+  TMStoreOption (..),
+  newTMStore,
+  storeRecorder,
+  lookupThreatModelSummary,
+) where
+
+import Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.=))
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Tagged (Tagged (..))
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import Test.Tasty.Options (IsOption (..))
+
+-- | Structured summary of a threat-model test case.
+data ThreatModelSummary = ThreatModelSummary
+  { tmsName :: !Text
+  , tmsTested :: !Int
+  , tmsTotal :: !Int
+  , tmsPassed :: !Int
+  , tmsFailed :: !Int
+  , tmsSkipped :: !Int
+  , tmsErrors :: !Int
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON ThreatModelSummary where
+  toJSON s =
+    object
+      [ "name" .= tmsName s
+      , "tested" .= tmsTested s
+      , "total" .= tmsTotal s
+      , "passed" .= tmsPassed s
+      , "failed" .= tmsFailed s
+      , "skipped" .= tmsSkipped s
+      , "errors" .= tmsErrors s
+      ]
+
+instance FromJSON ThreatModelSummary where
+  parseJSON = withObject "ThreatModelSummary" $ \o ->
+    ThreatModelSummary
+      <$> o .: "name"
+      <*> o .: "tested"
+      <*> o .: "total"
+      <*> o .: "passed"
+      <*> o .: "failed"
+      <*> o .: "skipped"
+      <*> o .: "errors"
+
+-- | Mutable storage for threat-model summaries, owned by the reporter.
+newtype TMStore = TMStore (IORef (Map String ThreatModelSummary))
+
+{- | A recorder closure passed to test bodies via Tasty's option system.
+The default no-op makes summaries silently dropped when the streaming
+reporter is not active.
+-}
+newtype TMRecorder = TMRecorder
+  { tmRecord :: String -> ThreatModelSummary -> IO ()
+  }
+
+{- | Internal option carrying the live store. Set by `defaultMainStreaming`
+alongside the recorder so the reporter can read summaries back out.
+-}
+newtype TMStoreOption = TMStoreOption (Maybe TMStore)
+
+instance IsOption TMRecorder where
+  defaultValue = TMRecorder (\_ _ -> pure ())
+  parseValue = const Nothing
+  optionName = Tagged "tm-recorder"
+  optionHelp = Tagged "internal: threat-model summary recorder"
+
+instance IsOption TMStoreOption where
+  defaultValue = TMStoreOption Nothing
+  parseValue = const Nothing
+  optionName = Tagged "tm-store"
+  optionHelp = Tagged "internal: threat-model summary store handle"
+
+-- | Allocate fresh storage. Call once per reporter run.
+newTMStore :: IO TMStore
+newTMStore = TMStore <$> newIORef Map.empty
+
+-- | Build a recorder that writes into the given store.
+storeRecorder :: TMStore -> TMRecorder
+storeRecorder (TMStore ref) = TMRecorder $ \key s ->
+  atomicModifyIORef' ref $ \m -> (Map.insert key s m, ())
+
+-- | Look up a summary by key (does not delete).
+lookupThreatModelSummary :: TMStore -> String -> IO (Maybe ThreatModelSummary)
+lookupThreatModelSummary (TMStore ref) key =
+  Map.lookup key <$> readIORef ref

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming/Types.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming/Types.hs
@@ -5,7 +5,9 @@ module Convex.Tasty.Streaming.Types (
   FailureInfo (..),
 ) where
 
+import Convex.Tasty.Streaming.TMSummary (ThreatModelSummary)
 import Data.Aeson (ToJSON (..), object, (.=))
+import Data.Aeson.Types (Pair)
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -63,6 +65,7 @@ data Event
       , edOutcome :: !TestOutcome
       , edDuration :: !Double
       , edDescription :: !Text
+      , edThreatModel :: !(Maybe ThreatModelSummary)
       }
   | SuiteDone
       { esPassed :: !Int
@@ -89,7 +92,7 @@ instance ToJSON Event where
       , "message" .= msg
       , "percent" .= pct
       ]
-  toJSON (TestDone i outcome dur desc) =
+  toJSON (TestDone i outcome dur desc mTm) =
     object $
       [ "event" .= ("test_done" :: Text)
       , "id" .= i
@@ -97,12 +100,15 @@ instance ToJSON Event where
       , "description" .= desc
       ]
         <> outcomeFields outcome
+        <> threatModelFields mTm
    where
     outcomeFields TestSuccess = ["success" .= True]
     outcomeFields (TestFailure fi) =
       [ "success" .= False
       , "failure" .= fi
       ]
+    threatModelFields :: Maybe ThreatModelSummary -> [Pair]
+    threatModelFields = maybe [] (\s -> ["threat_model" .= s])
   toJSON (SuiteDone p f dur) =
     object
       [ "event" .= ("suite_done" :: Text)

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming/Types.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming/Types.hs
@@ -6,7 +6,7 @@ module Convex.Tasty.Streaming.Types (
 ) where
 
 import Convex.Tasty.Streaming.TMSummary (ThreatModelSummary)
-import Data.Aeson (ToJSON (..), object, (.=))
+import Data.Aeson (ToJSON (..), Value, object, (.=))
 import Data.Aeson.Types (Pair)
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -67,6 +67,11 @@ data Event
       , edDescription :: !Text
       , edThreatModel :: !(Maybe ThreatModelSummary)
       }
+  | TestTrace
+      { ettTestId :: !Int
+      , ettCategory :: !Text
+      , ettTrace :: !Value -- pre-serialized IterationTrace JSON
+      }
   | SuiteDone
       { esPassed :: !Int
       , esFailed :: !Int
@@ -109,6 +114,13 @@ instance ToJSON Event where
       ]
     threatModelFields :: Maybe ThreatModelSummary -> [Pair]
     threatModelFields = maybe [] (\s -> ["threat_model" .= s])
+  toJSON (TestTrace i cat trace) =
+    object
+      [ "event" .= ("test_trace" :: Text)
+      , "id" .= i
+      , "category" .= cat
+      , "trace" .= trace
+      ]
   toJSON (SuiteDone p f dur) =
     object
       [ "event" .= ("suite_done" :: Text)

--- a/src/tasty-streaming/schema/streaming-events.schema.json
+++ b/src/tasty-streaming/schema/streaming-events.schema.json
@@ -1,0 +1,1244 @@
+{
+    "$defs": {
+        "AssetSummary": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "policyId": {
+                    "type": "string"
+                },
+                "quantity": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "policyId",
+                "name",
+                "quantity"
+            ],
+            "type": "object"
+        },
+        "Event": {
+            "discriminator": {
+                "mapping": {},
+                "propertyName": "event"
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "event": {
+                            "enum": [
+                                "suite_started"
+                            ],
+                            "type": "string"
+                        },
+                        "tests": {
+                            "items": {
+                                "$ref": "#/$defs/TestInfo"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "event",
+                        "tests"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "event": {
+                            "enum": [
+                                "test_started"
+                            ],
+                            "type": "string"
+                        },
+                        "id": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "event",
+                        "id"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "event": {
+                            "enum": [
+                                "test_progress"
+                            ],
+                            "type": "string"
+                        },
+                        "id": {
+                            "type": "integer"
+                        },
+                        "message": {
+                            "type": "string"
+                        },
+                        "percent": {
+                            "format": "float",
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "event",
+                        "id",
+                        "message",
+                        "percent"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "duration": {
+                            "format": "double",
+                            "type": "number"
+                        },
+                        "event": {
+                            "enum": [
+                                "test_done"
+                            ],
+                            "type": "string"
+                        },
+                        "failure": {
+                            "$ref": "#/$defs/FailureInfo"
+                        },
+                        "id": {
+                            "type": "integer"
+                        },
+                        "success": {
+                            "type": "boolean"
+                        },
+                        "threat_model": {
+                            "$ref": "#/$defs/ThreatModelSummary"
+                        }
+                    },
+                    "required": [
+                        "event",
+                        "id",
+                        "duration",
+                        "description",
+                        "success"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "category": {
+                            "type": "string"
+                        },
+                        "event": {
+                            "enum": [
+                                "test_trace"
+                            ],
+                            "type": "string"
+                        },
+                        "id": {
+                            "type": "integer"
+                        },
+                        "trace": {
+                            "$ref": "#/$defs/IterationTrace"
+                        }
+                    },
+                    "required": [
+                        "event",
+                        "id",
+                        "category",
+                        "trace"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "duration": {
+                            "format": "double",
+                            "type": "number"
+                        },
+                        "event": {
+                            "enum": [
+                                "suite_done"
+                            ],
+                            "type": "string"
+                        },
+                        "failed": {
+                            "type": "integer"
+                        },
+                        "passed": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "event",
+                        "passed",
+                        "failed",
+                        "duration"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "FailureInfo": {
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "reason",
+                "message"
+            ],
+            "type": "object"
+        },
+        "IterationStatus": {
+            "discriminator": {
+                "mapping": {},
+                "propertyName": "status"
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "status": {
+                            "enum": [
+                                "success"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "status"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "message": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "enum": [
+                                "failure"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "status",
+                        "message"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "message": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "enum": [
+                                "discarded"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "status",
+                        "message"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "IterationTrace": {
+            "properties": {
+                "index": {
+                    "type": "integer"
+                },
+                "status": {
+                    "$ref": "#/$defs/IterationStatus"
+                },
+                "threatModels": {
+                    "items": {
+                        "$ref": "#/$defs/ThreatModelTrace"
+                    },
+                    "type": "array"
+                },
+                "transitions": {
+                    "items": {
+                        "$ref": "#/$defs/Transition"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "index",
+                "status",
+                "transitions",
+                "threatModels"
+            ],
+            "type": "object"
+        },
+        "TestInfo": {
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "path": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "id",
+                "name",
+                "path"
+            ],
+            "type": "object"
+        },
+        "ThreatModelSummary": {
+            "properties": {
+                "errors": {
+                    "type": "integer"
+                },
+                "failed": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "passed": {
+                    "type": "integer"
+                },
+                "skipped": {
+                    "type": "integer"
+                },
+                "tested": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "name",
+                "tested",
+                "total",
+                "passed",
+                "failed",
+                "skipped",
+                "errors"
+            ],
+            "type": "object"
+        },
+        "ThreatModelTrace": {
+            "properties": {
+                "modifications": {
+                    "items": {
+                        "$ref": "#/$defs/TxMod"
+                    },
+                    "type": "array"
+                },
+                "modifiedTx": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/TxSummary"
+                        }
+                    ],
+                    "nullable": true
+                },
+                "name": {
+                    "type": "string"
+                },
+                "originalTx": {
+                    "$ref": "#/$defs/TxSummary"
+                },
+                "outcome": {
+                    "$ref": "#/$defs/ThreatModelTraceOutcome"
+                },
+                "targetTxIndex": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "name",
+                "targetTxIndex",
+                "modifications",
+                "originalTx",
+                "modifiedTx",
+                "outcome"
+            ],
+            "type": "object"
+        },
+        "ThreatModelTraceOutcome": {
+            "discriminator": {
+                "mapping": {},
+                "propertyName": "status"
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "status": {
+                            "enum": [
+                                "passed"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "status"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "reason": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "enum": [
+                                "failed"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "status",
+                        "reason"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "reason": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "enum": [
+                                "skipped"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "status",
+                        "reason"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "message": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "enum": [
+                                "error"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "status",
+                        "message"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "Transition": {
+            "properties": {
+                "action": {
+                    "type": "string"
+                },
+                "result": {
+                    "$ref": "#/$defs/TransitionResult"
+                },
+                "stateAfter": {},
+                "stateBefore": {},
+                "stepIndex": {
+                    "type": "integer"
+                },
+                "transaction": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/TxSummary"
+                        }
+                    ],
+                    "nullable": true
+                }
+            },
+            "required": [
+                "stepIndex",
+                "action",
+                "stateBefore",
+                "stateAfter",
+                "transaction",
+                "result"
+            ],
+            "type": "object"
+        },
+        "TransitionResult": {
+            "discriminator": {
+                "mapping": {},
+                "propertyName": "status"
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "status": {
+                            "enum": [
+                                "success"
+                            ],
+                            "type": "string"
+                        },
+                        "txId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "status",
+                        "txId"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "error": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "enum": [
+                                "failure"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "status",
+                        "error"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "TxInputSummary": {
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "utxo": {
+                    "type": "string"
+                },
+                "value": {
+                    "$ref": "#/$defs/ValueSummary"
+                }
+            },
+            "required": [
+                "utxo",
+                "address",
+                "value"
+            ],
+            "type": "object"
+        },
+        "TxMod": {
+            "discriminator": {
+                "mapping": {},
+                "propertyName": "type"
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "removeInput"
+                            ],
+                            "type": "string"
+                        },
+                        "utxo": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "utxo"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "index": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "enum": [
+                                "removeOutput"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "index"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "address": {
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        "datum": {
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        "index": {
+                            "type": "integer"
+                        },
+                        "referenceScript": {
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        "type": {
+                            "enum": [
+                                "changeOutput"
+                            ],
+                            "type": "string"
+                        },
+                        "value": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/$defs/ValueSummary"
+                                }
+                            ],
+                            "nullable": true
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "index",
+                        "address",
+                        "value",
+                        "datum",
+                        "referenceScript"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "address": {
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        "datum": {
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        "referenceScript": {
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        "type": {
+                            "enum": [
+                                "changeInput"
+                            ],
+                            "type": "string"
+                        },
+                        "utxo": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/$defs/ValueSummary"
+                                }
+                            ],
+                            "nullable": true
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "utxo",
+                        "address",
+                        "value",
+                        "datum",
+                        "referenceScript"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "datum": {
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        "redeemer": {
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        "referenceScript": {
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        "type": {
+                            "enum": [
+                                "changeScriptInput"
+                            ],
+                            "type": "string"
+                        },
+                        "utxo": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/$defs/ValueSummary"
+                                }
+                            ],
+                            "nullable": true
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "utxo",
+                        "value",
+                        "datum",
+                        "redeemer",
+                        "referenceScript"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "lowerBound": {
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        "type": {
+                            "enum": [
+                                "changeValidityRange"
+                            ],
+                            "type": "string"
+                        },
+                        "upperBound": {
+                            "nullable": true,
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "lowerBound",
+                        "upperBound"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "address": {
+                            "type": "string"
+                        },
+                        "datum": {
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        "referenceScript": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "enum": [
+                                "addOutput"
+                            ],
+                            "type": "string"
+                        },
+                        "value": {
+                            "$ref": "#/$defs/ValueSummary"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "address",
+                        "value",
+                        "datum",
+                        "referenceScript"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "address": {
+                            "type": "string"
+                        },
+                        "datum": {
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        "isReferenceInput": {
+                            "type": "boolean"
+                        },
+                        "referenceScript": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "enum": [
+                                "addInput"
+                            ],
+                            "type": "string"
+                        },
+                        "value": {
+                            "$ref": "#/$defs/ValueSummary"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "address",
+                        "value",
+                        "datum",
+                        "referenceScript",
+                        "isReferenceInput"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "datum": {
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        "redeemer": {
+                            "type": "string"
+                        },
+                        "scriptHash": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "enum": [
+                                "addReferenceScriptInput"
+                            ],
+                            "type": "string"
+                        },
+                        "value": {
+                            "$ref": "#/$defs/ValueSummary"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "scriptHash",
+                        "value",
+                        "datum",
+                        "redeemer"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "datum": {
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        "redeemer": {
+                            "type": "string"
+                        },
+                        "referenceScript": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "enum": [
+                                "addPlutusScriptInput"
+                            ],
+                            "type": "string"
+                        },
+                        "value": {
+                            "$ref": "#/$defs/ValueSummary"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "value",
+                        "datum",
+                        "redeemer",
+                        "referenceScript"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "datum": {
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        "referenceScript": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "enum": [
+                                "addPlutusScriptReferenceInput"
+                            ],
+                            "type": "string"
+                        },
+                        "value": {
+                            "$ref": "#/$defs/ValueSummary"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "value",
+                        "datum",
+                        "referenceScript"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "isReferenceInput": {
+                            "type": "boolean"
+                        },
+                        "referenceScript": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "enum": [
+                                "addSimpleScriptInput"
+                            ],
+                            "type": "string"
+                        },
+                        "value": {
+                            "$ref": "#/$defs/ValueSummary"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "value",
+                        "referenceScript",
+                        "isReferenceInput"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "assetName": {
+                            "type": "string"
+                        },
+                        "quantity": {
+                            "type": "integer"
+                        },
+                        "redeemer": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "enum": [
+                                "addPlutusScriptMint"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "assetName",
+                        "quantity",
+                        "redeemer"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "keyHash": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "enum": [
+                                "removeRequiredSigner"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "keyHash"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "replaceTx"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "TxOutputSummary": {
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "datum": {
+                    "nullable": true,
+                    "type": "string"
+                },
+                "utxo": {
+                    "type": "string"
+                },
+                "value": {
+                    "$ref": "#/$defs/ValueSummary"
+                }
+            },
+            "required": [
+                "utxo",
+                "address",
+                "value",
+                "datum"
+            ],
+            "type": "object"
+        },
+        "TxSummary": {
+            "properties": {
+                "fee": {
+                    "type": "integer"
+                },
+                "id": {
+                    "nullable": true,
+                    "type": "string"
+                },
+                "inputs": {
+                    "items": {
+                        "$ref": "#/$defs/TxInputSummary"
+                    },
+                    "type": "array"
+                },
+                "mint": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/ValueSummary"
+                        }
+                    ],
+                    "nullable": true
+                },
+                "outputs": {
+                    "items": {
+                        "$ref": "#/$defs/TxOutputSummary"
+                    },
+                    "type": "array"
+                },
+                "signers": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "validRange": {
+                    "nullable": true,
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "inputs",
+                "outputs",
+                "mint",
+                "fee",
+                "signers",
+                "validRange"
+            ],
+            "type": "object"
+        },
+        "ValueSummary": {
+            "properties": {
+                "assets": {
+                    "items": {
+                        "$ref": "#/$defs/AssetSummary"
+                    },
+                    "type": "array"
+                },
+                "lovelace": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "lovelace",
+                "assets"
+            ],
+            "type": "object"
+        }
+    },
+    "$id": "https://github.com/j-mueller/sc-tools/streaming-events.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "A single NDJSON line from the sc-tools test streaming reporter",
+    "oneOf": [
+        {
+            "properties": {
+                "event": {
+                    "enum": [
+                        "suite_started"
+                    ],
+                    "type": "string"
+                },
+                "tests": {
+                    "items": {
+                        "$ref": "#/$defs/TestInfo"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "event",
+                "tests"
+            ],
+            "type": "object"
+        },
+        {
+            "properties": {
+                "event": {
+                    "enum": [
+                        "test_started"
+                    ],
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "event",
+                "id"
+            ],
+            "type": "object"
+        },
+        {
+            "properties": {
+                "event": {
+                    "enum": [
+                        "test_progress"
+                    ],
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "percent": {
+                    "format": "float",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "event",
+                "id",
+                "message",
+                "percent"
+            ],
+            "type": "object"
+        },
+        {
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "duration": {
+                    "format": "double",
+                    "type": "number"
+                },
+                "event": {
+                    "enum": [
+                        "test_done"
+                    ],
+                    "type": "string"
+                },
+                "failure": {
+                    "$ref": "#/$defs/FailureInfo"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "success": {
+                    "type": "boolean"
+                },
+                "threat_model": {
+                    "$ref": "#/$defs/ThreatModelSummary"
+                }
+            },
+            "required": [
+                "event",
+                "id",
+                "duration",
+                "description",
+                "success"
+            ],
+            "type": "object"
+        },
+        {
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "event": {
+                    "enum": [
+                        "test_trace"
+                    ],
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "trace": {
+                    "$ref": "#/$defs/IterationTrace"
+                }
+            },
+            "required": [
+                "event",
+                "id",
+                "category",
+                "trace"
+            ],
+            "type": "object"
+        },
+        {
+            "properties": {
+                "duration": {
+                    "format": "double",
+                    "type": "number"
+                },
+                "event": {
+                    "enum": [
+                        "suite_done"
+                    ],
+                    "type": "string"
+                },
+                "failed": {
+                    "type": "integer"
+                },
+                "passed": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "event",
+                "passed",
+                "failed",
+                "duration"
+            ],
+            "type": "object"
+        }
+    ],
+    "title": "SC-Tools Streaming Event"
+}

--- a/src/testing-interface/convex-testing-interface.cabal
+++ b/src/testing-interface/convex-testing-interface.cabal
@@ -75,6 +75,7 @@ library
     , convex-coin-selection
     , convex-mockchain
     , convex-optics
+    , convex-tasty-streaming
     , convex-wallet
     , HUnit
     , lens

--- a/src/testing-interface/convex-testing-interface.cabal
+++ b/src/testing-interface/convex-testing-interface.cabal
@@ -79,6 +79,7 @@ library
     , convex-coin-selection
     , convex-mockchain
     , convex-optics
+    , convex-tasty-streaming
     , convex-wallet
     , HUnit
     , lens

--- a/src/testing-interface/convex-testing-interface.cabal
+++ b/src/testing-interface/convex-testing-interface.cabal
@@ -42,6 +42,8 @@ library
   import:          lang
   exposed-modules:
     Convex.TestingInterface
+    Convex.TestingInterface.Trace
+    Convex.TestingInterface.Trace.TxSummary
     Convex.ThreatModel
     Convex.ThreatModel.All
     Convex.ThreatModel.Cardano.Api
@@ -149,6 +151,7 @@ test-suite convex-testing-interface-test
 
   autogen-modules: Paths_convex_testing_interface
   build-depends:
+    , aeson
     , base                      >=4.14.0
     , bytestring
     , cardano-api

--- a/src/testing-interface/lib/Convex/TestingInterface.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface.hs
@@ -63,7 +63,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Test.HUnit (Assertion)
 import Test.QuickCheck (Arbitrary (..), Gen, Property, counterexample, discard, elements, frequency, oneof, property)
 import Test.QuickCheck.Monadic (PropertyM, monadicIO, monitor, pick, run)
-import Test.Tasty (DependencyType (..), TestTree, sequentialTestGroup, testGroup, withResource)
+import Test.Tasty (DependencyType (..), TestTree, askOption, sequentialTestGroup, testGroup, withResource)
 import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import Test.Tasty.HUnit (assertFailure, testCaseSteps)
 import Test.Tasty.QuickCheck (testProperty)
@@ -80,6 +80,7 @@ import Convex.MockChain (MockChainState (..), MockchainT, initialStateFor, runMo
 import Convex.MockChain.Defaults qualified as Defaults
 import Convex.MonadLog (MonadLog)
 import Convex.NodeParams (NodeParams (..))
+import Convex.Tasty.Streaming.TMSummary (TMRecorder, ThreatModelSummary (..), tmRecord)
 import Convex.ThreatModel (SigningWallet (AutoSign), ThreatModel (..), ThreatModelOutcome (..), getThreatModelName, runThreatModelCheck, threatModelEnvs)
 import Convex.ThreatModel.All (allThreatModels)
 import Convex.Wallet.MockWallet qualified as Wallet
@@ -94,6 +95,7 @@ import Data.List (deleteFirstsBy)
 import Data.Map qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Set qualified as Set
+import Data.Text qualified as T
 import Data.Word (Word32)
 import GHC.Generics (Generic)
 import PlutusTx.Coverage (
@@ -322,11 +324,11 @@ propRunActionsWithOptions groupName opts =
 
   threatModelGroup _ [] = []
   threatModelGroup getTmResultsRef tms' =
-    [testGroup "Threat models" $ zipWith (threatModelTestCase getTmResultsRef) [1 ..] tms']
+    [testGroup "Threat models" $ zipWith (threatModelTestCase getTmResultsRef "Threat models") [1 ..] tms']
 
   expectedVulnGroup _ [] = []
   expectedVulnGroup getTmResultsRef evs' =
-    [testGroup "Expected vulnerabilities" $ zipWith (expectedVulnTestCase getTmResultsRef) [1 ..] evs']
+    [testGroup "Expected vulnerabilities" $ zipWith (expectedVulnTestCase getTmResultsRef "Expected vulnerabilities") [1 ..] evs']
 
 -- | Negative test: check that invalid actions fail
 negativeTest
@@ -455,65 +457,85 @@ positiveTest opts mGetTmResultsRef tms evs = monadicIO $ do
 -- | Create a test case for displaying threat model results
 threatModelTestCase
   :: IO (IORef ThreatModelResults)
+  -> String
+  -- ^ Tasty group name (for keying summaries)
   -> Int
   -- ^ Index for fallback naming
   -> ThreatModel ()
   -- ^ The threat model
   -> TestTree
-threatModelTestCase getTmResultsRef idx tm =
+threatModelTestCase getTmResultsRef groupName idx tm =
   let name = fromMaybe ("Threat model " <> show idx) (getThreatModelName tm)
-   in testCaseSteps name $ \step -> do
-        tmRef <- getTmResultsRef
-        allResults <- readIORef tmRef
-        let outcomes = fromMaybe [] (Map.lookup name allResults)
-            total = length outcomes
-            numPassed = length [() | TMPassed <- outcomes]
-            numSkipped = length [() | TMSkipped <- outcomes]
-            numErrors = length [() | TMError _ <- outcomes]
-            errors = [msg | TMError msg <- outcomes]
+      key = groupName <> "/" <> name
+   in askOption $ \(recorder :: TMRecorder) ->
+        testCaseSteps name $ \step -> do
+          tmRef <- getTmResultsRef
+          allResults <- readIORef tmRef
+          let outcomes = fromMaybe [] (Map.lookup name allResults)
+              total = length outcomes
+              numPassed = length [() | TMPassed <- outcomes]
+              numFailed = length [() | TMFailed _ <- outcomes]
+              numSkipped = length [() | TMSkipped <- outcomes]
+              numErrors = length [() | TMError _ <- outcomes]
+              errors = [msg | TMError msg <- outcomes]
+              tested = numPassed + numFailed
+              summary =
+                ThreatModelSummary
+                  { tmsName = T.pack name
+                  , tmsTested = tested
+                  , tmsTotal = total
+                  , tmsPassed = numPassed
+                  , tmsFailed = numFailed
+                  , tmsSkipped = numSkipped
+                  , tmsErrors = numErrors
+                  }
 
-        -- Report errors as warnings (don't fail the test)
-        case errors of
-          [] -> pure ()
-          _ -> do
-            step $ "WARNING: " <> show numErrors <> " error(s) during threat model execution"
-            mapM_ (step . ("  " <>)) (take 3 errors)
-            case drop 3 errors of
-              [] -> pure ()
-              remaining -> step $ "  ... and " <> show (length remaining) <> " more"
+          -- Report errors as warnings (don't fail the test)
+          case errors of
+            [] -> pure ()
+            _ -> do
+              step $ "WARNING: " <> show numErrors <> " error(s) during threat model execution"
+              mapM_ (step . ("  " <>)) (take 3 errors)
+              case drop 3 errors of
+                [] -> pure ()
+                remaining -> step $ "  ... and " <> show (length remaining) <> " more"
 
-        if total == 0
-          then step "No transactions were generated by positive tests"
-          else
-            if numSkipped + numErrors == total
-              then
-                step $
-                  "SKIPPED: Precondition never met (0/"
-                    <> show total
-                    <> " transactions applicable)"
-              else do
-                step $
-                  "Tested "
-                    <> show numPassed
-                    <> "/"
-                    <> show total
-                    <> " transactions ("
-                    <> show numSkipped
-                    <> " skipped, "
-                    <> show numErrors
-                    <> " errors)"
-                case [msg | TMFailed msg <- outcomes] of
-                  [] -> pure ()
-                  (firstFailure : rest) ->
-                    assertFailure $
-                      unlines
-                        [ "FAILED (after " <> show (numPassed + 1) <> " tests): Vulnerability detected"
-                        , ""
-                        , firstFailure
-                        , if null rest
-                            then ""
-                            else "... and " <> show (length rest) <> " more similar failure(s) suppressed"
-                        ]
+          if total == 0
+            then do
+              step "No transactions were generated by positive tests"
+              tmRecord recorder key summary
+            else
+              if numSkipped + numErrors == total
+                then do
+                  step $
+                    "SKIPPED: Precondition never met (0/"
+                      <> show total
+                      <> " transactions applicable)"
+                  tmRecord recorder key summary
+                else do
+                  step $
+                    "Tested "
+                      <> show numPassed
+                      <> "/"
+                      <> show total
+                      <> " transactions ("
+                      <> show numSkipped
+                      <> " skipped, "
+                      <> show numErrors
+                      <> " errors)"
+                  tmRecord recorder key summary
+                  case [msg | TMFailed msg <- outcomes] of
+                    [] -> pure ()
+                    (firstFailure : rest) ->
+                      assertFailure $
+                        unlines
+                          [ "FAILED (after " <> show (numPassed + 1) <> " tests): Vulnerability detected"
+                          , ""
+                          , firstFailure
+                          , if null rest
+                              then ""
+                              else "... and " <> show (length rest) <> " more similar failure(s) suppressed"
+                          ]
 
 {- | Create a test case for expected vulnerabilities with inverted pass/fail semantics.
 TMFailed = GOOD (vulnerability was correctly detected)
@@ -523,76 +545,96 @@ Output is quiet — no verbose transaction dump details, just stats.
 -}
 expectedVulnTestCase
   :: IO (IORef ThreatModelResults)
+  -> String
+  -- ^ Tasty group name (for keying summaries)
   -> Int
   -- ^ Index for fallback naming
   -> ThreatModel ()
   -- ^ The threat model expected to find vulnerabilities
   -> TestTree
-expectedVulnTestCase getTmResultsRef idx tm =
+expectedVulnTestCase getTmResultsRef groupName idx tm =
   let name = fromMaybe ("Expected vulnerability " <> show idx) (getThreatModelName tm)
-   in testCaseSteps name $ \step -> do
-        tmRef <- getTmResultsRef
-        allResults <- readIORef tmRef
-        let outcomes = fromMaybe [] (Map.lookup name allResults)
-            total = length outcomes
-            -- In expected vulnerability context:
-            -- TMFailed = vulnerability detected = GOOD
-            -- TMPassed = no vulnerability found = BAD
-            -- TMError = crashed, doesn't count either way
-            numFound = length [() | TMFailed _ <- outcomes] -- Good: vulnerability detected
-            numNotFound = length [() | TMPassed <- outcomes] -- Bad: expected vuln not found
-            numSkipped = length [() | TMSkipped <- outcomes]
-            numErrors = length [() | TMError _ <- outcomes]
-            errors = [msg | TMError msg <- outcomes]
-            tested = numFound + numNotFound
+      key = groupName <> "/" <> name
+   in askOption $ \(recorder :: TMRecorder) ->
+        testCaseSteps name $ \step -> do
+          tmRef <- getTmResultsRef
+          allResults <- readIORef tmRef
+          let outcomes = fromMaybe [] (Map.lookup name allResults)
+              total = length outcomes
+              -- In expected vulnerability context:
+              -- TMFailed = vulnerability detected = GOOD
+              -- TMPassed = no vulnerability found = BAD
+              -- TMError = crashed, doesn't count either way
+              numFound = length [() | TMFailed _ <- outcomes] -- Good: vulnerability detected
+              numNotFound = length [() | TMPassed <- outcomes] -- Bad: expected vuln not found
+              numSkipped = length [() | TMSkipped <- outcomes]
+              numErrors = length [() | TMError _ <- outcomes]
+              errors = [msg | TMError msg <- outcomes]
+              tested = numFound + numNotFound
+              summary =
+                ThreatModelSummary
+                  { tmsName = T.pack name
+                  , tmsTested = tested
+                  , tmsTotal = total
+                  , tmsPassed = numNotFound -- TMPassed count
+                  , tmsFailed = numFound -- TMFailed count
+                  , tmsSkipped = numSkipped
+                  , tmsErrors = numErrors
+                  }
 
-        -- Report errors as warnings (don't fail the test for errors alone)
-        case errors of
-          [] -> pure ()
-          _ -> do
-            step $ "WARNING: " <> show numErrors <> " error(s) during threat model execution"
-            mapM_ (step . ("  " <>)) (take 3 errors)
-            case drop 3 errors of
-              [] -> pure ()
-              remaining -> step $ "  ... and " <> show (length remaining) <> " more"
+          -- Report errors as warnings (don't fail the test for errors alone)
+          case errors of
+            [] -> pure ()
+            _ -> do
+              step $ "WARNING: " <> show numErrors <> " error(s) during threat model execution"
+              mapM_ (step . ("  " <>)) (take 3 errors)
+              case drop 3 errors of
+                [] -> pure ()
+                remaining -> step $ "  ... and " <> show (length remaining) <> " more"
 
-        if total == 0
-          then step "No transactions were generated by positive tests"
-          else
-            if numSkipped + numErrors == total
-              then
-                step $
-                  "SKIPPED: Precondition never met (0/"
-                    <> show total
-                    <> " transactions applicable)"
-              else
-                if numFound > 0
-                  then
-                    -- Good: at least one vulnerability was found
-                    step $
-                      "Vulnerability detected ("
-                        <> show numFound
-                        <> "/"
-                        <> show tested
-                        <> " transactions, "
-                        <> show numSkipped
-                        <> " skipped, "
-                        <> show numErrors
-                        <> " errors)"
-                  else
-                    if tested > 0
-                      then
-                        -- Bad: transactions were tested but no vulnerability found
-                        assertFailure $
-                          "Expected vulnerability NOT found in "
-                            <> show tested
-                            <> " tested transactions"
-                      else
-                        -- Edge case: all were skipped/errored (same as numSkipped + numErrors == total, but defensive)
-                        step $
-                          "SKIPPED: Precondition never met (0/"
-                            <> show total
-                            <> " transactions applicable)"
+          if total == 0
+            then do
+              step "No transactions were generated by positive tests"
+              tmRecord recorder key summary
+            else
+              if numSkipped + numErrors == total
+                then do
+                  step $
+                    "SKIPPED: Precondition never met (0/"
+                      <> show total
+                      <> " transactions applicable)"
+                  tmRecord recorder key summary
+                else
+                  if numFound > 0
+                    then do
+                      -- Good: at least one vulnerability was found
+                      step $
+                        "Vulnerability detected ("
+                          <> show numFound
+                          <> "/"
+                          <> show tested
+                          <> " transactions, "
+                          <> show numSkipped
+                          <> " skipped, "
+                          <> show numErrors
+                          <> " errors)"
+                      tmRecord recorder key summary
+                    else
+                      if tested > 0
+                        then do
+                          -- Bad: transactions were tested but no vulnerability found
+                          tmRecord recorder key summary
+                          assertFailure $
+                            "Expected vulnerability NOT found in "
+                              <> show tested
+                              <> " tested transactions"
+                        else do
+                          -- Edge case: all were skipped/errored (same as numSkipped + numErrors == total, but defensive)
+                          step $
+                            "SKIPPED: Precondition never met (0/"
+                              <> show total
+                              <> " transactions applicable)"
+                          tmRecord recorder key summary
 
 -- | Generate a number of actions (with a given maximum) and run them.
 runActions

--- a/src/testing-interface/lib/Convex/TestingInterface.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface.hs
@@ -374,7 +374,8 @@ negativeTest opts groupName recorder getIterRef = monadicIO $ do
     idx <- readIORef iterRef
     modifyIORef iterRef (+ 1)
     pure idx
-  if trEnabled recorder
+  enabled <- run $ trEnabled recorder
+  if enabled
     then negativeTestTraced @state opts groupName recorder iterIdx
     else negativeTestFast @state opts
 
@@ -411,7 +412,6 @@ negativeTestTraced opts groupName recorder iterIdx = do
       let trace =
             IterationTrace
               { itIndex = iterIdx
-              , itSeed = 0
               , itStatus = IterationFailure (formatBalanceTxError err)
               , itTransitions = []
               , itThreatModels = []
@@ -440,7 +440,6 @@ negativeTestTraced opts groupName recorder iterIdx = do
           let trace =
                 IterationTrace
                   { itIndex = iterIdx
-                  , itSeed = 0
                   , itStatus = IterationDiscarded (T.pack (show ex))
                   , itTransitions = transitions <> [badTransition (TransitionFailure (T.pack (show ex)))]
                   , itThreatModels = []
@@ -451,7 +450,6 @@ negativeTestTraced opts groupName recorder iterIdx = do
           let trace =
                 IterationTrace
                   { itIndex = iterIdx
-                  , itSeed = 0
                   , itStatus = IterationSuccess
                   , itTransitions = transitions <> [badTransition (TransitionFailure (T.pack (show ex)))]
                   , itThreatModels = []
@@ -466,7 +464,6 @@ negativeTestTraced opts groupName recorder iterIdx = do
               let trace =
                     IterationTrace
                       { itIndex = iterIdx
-                      , itSeed = 0
                       , itStatus = IterationSuccess
                       , itTransitions = transitions <> [badTransition (TransitionFailure (formatBalanceTxError err))]
                       , itThreatModels = []
@@ -480,7 +477,6 @@ negativeTestTraced opts groupName recorder iterIdx = do
               let trace =
                     IterationTrace
                       { itIndex = iterIdx
-                      , itSeed = 0
                       , itStatus = IterationFailure "Invalid action succeeded unexpectedly"
                       , itTransitions = transitions <> [badTransition (TransitionSuccess T.empty)]
                       , itThreatModels = []
@@ -559,7 +555,8 @@ positiveTest opts groupName mGetTmResultsRef tms evs recorder getIterRef = monad
     idx <- readIORef iterRef
     modifyIORef iterRef (+ 1)
     pure idx
-  if trEnabled recorder
+  enabled <- run $ trEnabled recorder
+  if enabled
     then positiveTestTraced @state opts groupName mGetTmResultsRef tms evs recorder iterIdx
     else positiveTestFast @state opts mGetTmResultsRef tms evs
 
@@ -613,7 +610,6 @@ positiveTestTraced opts groupName mGetTmResultsRef tms evs recorder iterIdx = do
       let trace =
             IterationTrace
               { itIndex = iterIdx
-              , itSeed = 0
               , itStatus = IterationFailure (formatBalanceTxError err)
               , itTransitions = []
               , itThreatModels = []
@@ -636,7 +632,6 @@ positiveTestTraced opts groupName mGetTmResultsRef tms evs recorder iterIdx = do
           trace =
             IterationTrace
               { itIndex = iterIdx
-              , itSeed = 0
               , itStatus = IterationSuccess
               , itTransitions = transitions
               , itThreatModels = tmTraces

--- a/src/testing-interface/lib/Convex/TestingInterface.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface.hs
@@ -63,7 +63,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Test.HUnit (Assertion)
 import Test.QuickCheck (Arbitrary (..), Gen, Property, counterexample, discard, elements, frequency, oneof, property)
 import Test.QuickCheck.Monadic (PropertyM, monadicIO, monitor, pick, run)
-import Test.Tasty (DependencyType (..), TestTree, sequentialTestGroup, testGroup, withResource)
+import Test.Tasty (DependencyType (..), TestTree, askOption, sequentialTestGroup, testGroup, withResource)
 import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import Test.Tasty.HUnit (assertFailure, testCaseSteps)
 import Test.Tasty.QuickCheck (testProperty)
@@ -80,6 +80,7 @@ import Convex.MockChain (MockChainState (..), MockchainT, initialStateFor, runMo
 import Convex.MockChain.Defaults qualified as Defaults
 import Convex.MonadLog (MonadLog)
 import Convex.NodeParams (NodeParams (..))
+import Convex.Tasty.Streaming.TMSummary (TMRecorder, ThreatModelSummary (..), tmRecord)
 import Convex.ThreatModel (SigningWallet (AutoSign), ThreatModel (..), ThreatModelOutcome (..), getThreatModelName, runThreatModelCheck, threatModelEnvs)
 import Convex.ThreatModel.All (allThreatModels)
 import Convex.Wallet.MockWallet qualified as Wallet
@@ -94,6 +95,7 @@ import Data.List (deleteFirstsBy)
 import Data.Map qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Set qualified as Set
+import Data.Text qualified as T
 import Data.Word (Word32)
 import GHC.Generics (Generic)
 import PlutusTx.Coverage (
@@ -325,11 +327,11 @@ propRunActionsWithOptions groupName opts =
 
   threatModelGroup _ [] = []
   threatModelGroup getTmResultsRef tms' =
-    [testGroup "Threat models" $ zipWith (threatModelTestCase getTmResultsRef) [1 ..] tms']
+    [testGroup "Threat models" $ zipWith (threatModelTestCase getTmResultsRef "Threat models") [1 ..] tms']
 
   expectedVulnGroup _ [] = []
   expectedVulnGroup getTmResultsRef evs' =
-    [testGroup "Expected vulnerabilities" $ zipWith (expectedVulnTestCase getTmResultsRef) [1 ..] evs']
+    [testGroup "Expected vulnerabilities" $ zipWith (expectedVulnTestCase getTmResultsRef "Expected vulnerabilities") [1 ..] evs']
 
 -- | Negative test: check that invalid actions fail
 negativeTest
@@ -458,65 +460,85 @@ positiveTest opts mGetTmResultsRef tms evs = monadicIO $ do
 -- | Create a test case for displaying threat model results
 threatModelTestCase
   :: IO (IORef ThreatModelResults)
+  -> String
+  -- ^ Tasty group name (for keying summaries)
   -> Int
   -- ^ Index for fallback naming
   -> ThreatModel ()
   -- ^ The threat model
   -> TestTree
-threatModelTestCase getTmResultsRef idx tm =
+threatModelTestCase getTmResultsRef groupName idx tm =
   let name = fromMaybe ("Threat model " <> show idx) (getThreatModelName tm)
-   in testCaseSteps name $ \step -> do
-        tmRef <- getTmResultsRef
-        allResults <- readIORef tmRef
-        let outcomes = fromMaybe [] (Map.lookup name allResults)
-            total = length outcomes
-            numPassed = length [() | TMPassed <- outcomes]
-            numSkipped = length [() | TMSkipped <- outcomes]
-            numErrors = length [() | TMError _ <- outcomes]
-            errors = [msg | TMError msg <- outcomes]
+      key = groupName <> "/" <> name
+   in askOption $ \(recorder :: TMRecorder) ->
+        testCaseSteps name $ \step -> do
+          tmRef <- getTmResultsRef
+          allResults <- readIORef tmRef
+          let outcomes = fromMaybe [] (Map.lookup name allResults)
+              total = length outcomes
+              numPassed = length [() | TMPassed <- outcomes]
+              numFailed = length [() | TMFailed _ <- outcomes]
+              numSkipped = length [() | TMSkipped <- outcomes]
+              numErrors = length [() | TMError _ <- outcomes]
+              errors = [msg | TMError msg <- outcomes]
+              tested = numPassed + numFailed
+              summary =
+                ThreatModelSummary
+                  { tmsName = T.pack name
+                  , tmsTested = tested
+                  , tmsTotal = total
+                  , tmsPassed = numPassed
+                  , tmsFailed = numFailed
+                  , tmsSkipped = numSkipped
+                  , tmsErrors = numErrors
+                  }
 
-        -- Report errors as warnings (don't fail the test)
-        case errors of
-          [] -> pure ()
-          _ -> do
-            step $ "WARNING: " <> show numErrors <> " error(s) during threat model execution"
-            mapM_ (step . ("  " <>)) (take 3 errors)
-            case drop 3 errors of
-              [] -> pure ()
-              remaining -> step $ "  ... and " <> show (length remaining) <> " more"
+          -- Report errors as warnings (don't fail the test)
+          case errors of
+            [] -> pure ()
+            _ -> do
+              step $ "WARNING: " <> show numErrors <> " error(s) during threat model execution"
+              mapM_ (step . ("  " <>)) (take 3 errors)
+              case drop 3 errors of
+                [] -> pure ()
+                remaining -> step $ "  ... and " <> show (length remaining) <> " more"
 
-        if total == 0
-          then step "No transactions were generated by positive tests"
-          else
-            if numSkipped + numErrors == total
-              then
-                step $
-                  "SKIPPED: Precondition never met (0/"
-                    <> show total
-                    <> " transactions applicable)"
-              else do
-                step $
-                  "Tested "
-                    <> show numPassed
-                    <> "/"
-                    <> show total
-                    <> " transactions ("
-                    <> show numSkipped
-                    <> " skipped, "
-                    <> show numErrors
-                    <> " errors)"
-                case [msg | TMFailed msg <- outcomes] of
-                  [] -> pure ()
-                  (firstFailure : rest) ->
-                    assertFailure $
-                      unlines
-                        [ "FAILED (after " <> show (numPassed + 1) <> " tests): Vulnerability detected"
-                        , ""
-                        , firstFailure
-                        , if null rest
-                            then ""
-                            else "... and " <> show (length rest) <> " more similar failure(s) suppressed"
-                        ]
+          if total == 0
+            then do
+              step "No transactions were generated by positive tests"
+              tmRecord recorder key summary
+            else
+              if numSkipped + numErrors == total
+                then do
+                  step $
+                    "SKIPPED: Precondition never met (0/"
+                      <> show total
+                      <> " transactions applicable)"
+                  tmRecord recorder key summary
+                else do
+                  step $
+                    "Tested "
+                      <> show numPassed
+                      <> "/"
+                      <> show total
+                      <> " transactions ("
+                      <> show numSkipped
+                      <> " skipped, "
+                      <> show numErrors
+                      <> " errors)"
+                  tmRecord recorder key summary
+                  case [msg | TMFailed msg <- outcomes] of
+                    [] -> pure ()
+                    (firstFailure : rest) ->
+                      assertFailure $
+                        unlines
+                          [ "FAILED (after " <> show (numPassed + 1) <> " tests): Vulnerability detected"
+                          , ""
+                          , firstFailure
+                          , if null rest
+                              then ""
+                              else "... and " <> show (length rest) <> " more similar failure(s) suppressed"
+                          ]
 
 {- | Create a test case for expected vulnerabilities with inverted pass/fail semantics.
 TMFailed = GOOD (vulnerability was correctly detected)
@@ -526,76 +548,96 @@ Output is quiet — no verbose transaction dump details, just stats.
 -}
 expectedVulnTestCase
   :: IO (IORef ThreatModelResults)
+  -> String
+  -- ^ Tasty group name (for keying summaries)
   -> Int
   -- ^ Index for fallback naming
   -> ThreatModel ()
   -- ^ The threat model expected to find vulnerabilities
   -> TestTree
-expectedVulnTestCase getTmResultsRef idx tm =
+expectedVulnTestCase getTmResultsRef groupName idx tm =
   let name = fromMaybe ("Expected vulnerability " <> show idx) (getThreatModelName tm)
-   in testCaseSteps name $ \step -> do
-        tmRef <- getTmResultsRef
-        allResults <- readIORef tmRef
-        let outcomes = fromMaybe [] (Map.lookup name allResults)
-            total = length outcomes
-            -- In expected vulnerability context:
-            -- TMFailed = vulnerability detected = GOOD
-            -- TMPassed = no vulnerability found = BAD
-            -- TMError = crashed, doesn't count either way
-            numFound = length [() | TMFailed _ <- outcomes] -- Good: vulnerability detected
-            numNotFound = length [() | TMPassed <- outcomes] -- Bad: expected vuln not found
-            numSkipped = length [() | TMSkipped <- outcomes]
-            numErrors = length [() | TMError _ <- outcomes]
-            errors = [msg | TMError msg <- outcomes]
-            tested = numFound + numNotFound
+      key = groupName <> "/" <> name
+   in askOption $ \(recorder :: TMRecorder) ->
+        testCaseSteps name $ \step -> do
+          tmRef <- getTmResultsRef
+          allResults <- readIORef tmRef
+          let outcomes = fromMaybe [] (Map.lookup name allResults)
+              total = length outcomes
+              -- In expected vulnerability context:
+              -- TMFailed = vulnerability detected = GOOD
+              -- TMPassed = no vulnerability found = BAD
+              -- TMError = crashed, doesn't count either way
+              numFound = length [() | TMFailed _ <- outcomes] -- Good: vulnerability detected
+              numNotFound = length [() | TMPassed <- outcomes] -- Bad: expected vuln not found
+              numSkipped = length [() | TMSkipped <- outcomes]
+              numErrors = length [() | TMError _ <- outcomes]
+              errors = [msg | TMError msg <- outcomes]
+              tested = numFound + numNotFound
+              summary =
+                ThreatModelSummary
+                  { tmsName = T.pack name
+                  , tmsTested = tested
+                  , tmsTotal = total
+                  , tmsPassed = numNotFound -- TMPassed count
+                  , tmsFailed = numFound -- TMFailed count
+                  , tmsSkipped = numSkipped
+                  , tmsErrors = numErrors
+                  }
 
-        -- Report errors as warnings (don't fail the test for errors alone)
-        case errors of
-          [] -> pure ()
-          _ -> do
-            step $ "WARNING: " <> show numErrors <> " error(s) during threat model execution"
-            mapM_ (step . ("  " <>)) (take 3 errors)
-            case drop 3 errors of
-              [] -> pure ()
-              remaining -> step $ "  ... and " <> show (length remaining) <> " more"
+          -- Report errors as warnings (don't fail the test for errors alone)
+          case errors of
+            [] -> pure ()
+            _ -> do
+              step $ "WARNING: " <> show numErrors <> " error(s) during threat model execution"
+              mapM_ (step . ("  " <>)) (take 3 errors)
+              case drop 3 errors of
+                [] -> pure ()
+                remaining -> step $ "  ... and " <> show (length remaining) <> " more"
 
-        if total == 0
-          then step "No transactions were generated by positive tests"
-          else
-            if numSkipped + numErrors == total
-              then
-                step $
-                  "SKIPPED: Precondition never met (0/"
-                    <> show total
-                    <> " transactions applicable)"
-              else
-                if numFound > 0
-                  then
-                    -- Good: at least one vulnerability was found
-                    step $
-                      "Vulnerability detected ("
-                        <> show numFound
-                        <> "/"
-                        <> show tested
-                        <> " transactions, "
-                        <> show numSkipped
-                        <> " skipped, "
-                        <> show numErrors
-                        <> " errors)"
-                  else
-                    if tested > 0
-                      then
-                        -- Bad: transactions were tested but no vulnerability found
-                        assertFailure $
-                          "Expected vulnerability NOT found in "
-                            <> show tested
-                            <> " tested transactions"
-                      else
-                        -- Edge case: all were skipped/errored (same as numSkipped + numErrors == total, but defensive)
-                        step $
-                          "SKIPPED: Precondition never met (0/"
-                            <> show total
-                            <> " transactions applicable)"
+          if total == 0
+            then do
+              step "No transactions were generated by positive tests"
+              tmRecord recorder key summary
+            else
+              if numSkipped + numErrors == total
+                then do
+                  step $
+                    "SKIPPED: Precondition never met (0/"
+                      <> show total
+                      <> " transactions applicable)"
+                  tmRecord recorder key summary
+                else
+                  if numFound > 0
+                    then do
+                      -- Good: at least one vulnerability was found
+                      step $
+                        "Vulnerability detected ("
+                          <> show numFound
+                          <> "/"
+                          <> show tested
+                          <> " transactions, "
+                          <> show numSkipped
+                          <> " skipped, "
+                          <> show numErrors
+                          <> " errors)"
+                      tmRecord recorder key summary
+                    else
+                      if tested > 0
+                        then do
+                          -- Bad: transactions were tested but no vulnerability found
+                          tmRecord recorder key summary
+                          assertFailure $
+                            "Expected vulnerability NOT found in "
+                              <> show tested
+                              <> " tested transactions"
+                        else do
+                          -- Edge case: all were skipped/errored (same as numSkipped + numErrors == total, but defensive)
+                          step $
+                            "SKIPPED: Precondition never met (0/"
+                              <> show total
+                              <> " transactions applicable)"
+                          tmRecord recorder key summary
 
 -- | Generate a number of actions (with a given maximum) and run them.
 runActions

--- a/src/testing-interface/lib/Convex/TestingInterface.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface.hs
@@ -1027,7 +1027,7 @@ toThreatModelTraces results = concatMap go results
   outcomeToTrace TMSkipped = TMTOSkipped "precondition not met"
   outcomeToTrace (TMError msg) = TMTOError (T.pack msg)
 
-  renderModifications (TxModifier mods) = map (T.pack . show) mods
+  renderModifications (TxModifier mods) = map toJSON mods
 
   emptyTxSummary =
     TxSummary

--- a/src/testing-interface/lib/Convex/TestingInterface.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
@@ -24,6 +25,10 @@ module Convex.TestingInterface (
   RunOptions (..),
   defaultRunOptions,
   genAction,
+  runActions,
+
+  -- * Trace recording
+  TraceRecorder (..),
 
   -- * The Testing Monad
   TestingMonadT (..),
@@ -74,15 +79,26 @@ import Control.Exception (SomeException, catch, throwIO, try)
 import Control.Lens ((&), (.~), (^.))
 import Control.Monad.Except (ExceptT, runExceptT)
 import Control.Monad.Trans (MonadTrans (..))
-import Convex.Class (MonadBlockchain, MonadMockchain, coverageData, getTxs)
-import Convex.CoinSelection (BalanceTxError, coverageFromBalanceTxError)
-import Convex.MockChain (MockChainState (..), MockchainT, initialStateFor, runMockchainIO, runMockchainT)
+import Convex.Class (MonadBlockchain, MonadMockchain, coverageData, getMockChainState, getTxs, getUtxo)
+import Convex.CoinSelection (BalanceTxError (..), BalancingError (..), coverageFromBalanceTxError)
+import Convex.MockChain (MockChainState (..), MockchainT, fromLedgerUTxO, initialStateFor, runMockchainIO, runMockchainT)
 import Convex.MockChain.Defaults qualified as Defaults
 import Convex.MonadLog (MonadLog)
 import Convex.NodeParams (NodeParams (..))
-import Convex.Tasty.Streaming.TMSummary (TMRecorder, ThreatModelSummary (..), tmRecord)
-import Convex.ThreatModel (SigningWallet (AutoSign), ThreatModel (..), ThreatModelOutcome (..), getThreatModelName, runThreatModelCheck, threatModelEnvs)
+import Convex.Tasty.Streaming.TMSummary (TMRecorder, ThreatModelSummary (..), TraceRecorder (..), tmRecord)
+import Convex.TestingInterface.Trace (
+  IterationStatus (..),
+  IterationTrace (..),
+  ThreatModelTrace (..),
+  ThreatModelTraceOutcome (..),
+  Transition (..),
+  TransitionResult (..),
+  TxSummary (..),
+ )
+import Convex.TestingInterface.Trace.TxSummary (summarizeTx)
+import Convex.ThreatModel (SigningWallet (AutoSign), ThreatModel (..), ThreatModelCheckEntry (..), ThreatModelOutcome (..), getThreatModelName, runThreatModelCheckTraced, threatModelEnvs)
 import Convex.ThreatModel.All (allThreatModels)
+import Convex.ThreatModel.TxModifier (TxModifier (..))
 import Convex.Wallet.MockWallet qualified as Wallet
 import Data.Aeson (ToJSON (..), (.=))
 import Data.Aeson qualified as Aeson
@@ -94,6 +110,7 @@ import Data.IORef (IORef, modifyIORef, newIORef, readIORef)
 import Data.List (deleteFirstsBy)
 import Data.Map qualified as Map
 import Data.Maybe (fromMaybe)
+
 import Data.Set qualified as Set
 import Data.Text qualified as T
 import Data.Word (Word32)
@@ -122,7 +139,7 @@ correctly.
 
 Minimal complete definition: 'Action', 'initialize', 'arbitraryAction', 'perform'
 -}
-class (Show state, Eq state, Show (Action state)) => TestingInterface state where
+class (Show state, Eq state, Show (Action state), ToJSON state) => TestingInterface state where
   {- | Actions that can be performed on the contract.
   This is typically a data type with one constructor per contract operation.
   -}
@@ -301,29 +318,34 @@ propRunActionsWithOptions
   -> RunOptions
   -> TestTree
 propRunActionsWithOptions groupName opts =
-  let tms = threatModels @state
-      evs = expectedVulnerabilities @state
-   in if null tms && null evs
-        then
-          -- No threat models: simple structure (backward compatible)
-          testGroup
-            groupName
-            [ testProperty "Positive tests" (positiveTest @state opts Nothing [] [])
-            , negativeTestTree
-            ]
-        else
-          -- Has threat models: two-phase approach with IORef
-          withResource (newIORef Map.empty) (\_ -> pure ()) $ \getTmResultsRef ->
-            sequentialTestGroup groupName AllFinish $
-              [ testProperty "Positive tests" (positiveTest @state opts (Just getTmResultsRef) tms evs)
-              , negativeTestTree
-              ]
-                <> threatModelGroup getTmResultsRef tms
-                <> expectedVulnGroup getTmResultsRef evs
+  askOption $ \(recorder :: TraceRecorder) ->
+    let tms = threatModels @state
+        evs = expectedVulnerabilities @state
+     in if null tms && null evs
+          then
+            -- No threat models: simple structure (backward compatible)
+            withResource (newIORef (0 :: Int)) (\_ -> pure ()) $ \getPosRef ->
+              withResource (newIORef (0 :: Int)) (\_ -> pure ()) $ \getNegRef ->
+                testGroup
+                  groupName
+                  [ testProperty "Positive tests" (positiveTest @state opts groupName Nothing [] [] recorder getPosRef)
+                  , negativeTestTree recorder getNegRef
+                  ]
+          else
+            -- Has threat models: two-phase approach with IORef
+            withResource (newIORef Map.empty) (\_ -> pure ()) $ \getTmResultsRef ->
+              withResource (newIORef (0 :: Int)) (\_ -> pure ()) $ \getPosRef ->
+                withResource (newIORef (0 :: Int)) (\_ -> pure ()) $ \getNegRef ->
+                  sequentialTestGroup groupName AllFinish $
+                    [ testProperty "Positive tests" (positiveTest @state opts groupName (Just getTmResultsRef) tms evs recorder getPosRef)
+                    , negativeTestTree recorder getNegRef
+                    ]
+                      <> threatModelGroup getTmResultsRef tms
+                      <> expectedVulnGroup getTmResultsRef evs
  where
-  negativeTestTree = case disableNegativeTesting opts of
-    Nothing -> testProperty "Negative tests" (negativeTest @state opts)
-    Just reason -> ignoreTestBecause reason $ testProperty "Negative tests" (negativeTest @state opts)
+  negativeTestTree recorder getNegRef = case disableNegativeTesting opts of
+    Nothing -> testProperty "Negative tests" (negativeTest @state opts groupName recorder getNegRef)
+    Just reason -> ignoreTestBecause reason $ testProperty "Negative tests" (negativeTest @state opts groupName recorder getNegRef)
 
   threatModelGroup _ [] = []
   threatModelGroup getTmResultsRef tms' =
@@ -338,8 +360,141 @@ negativeTest
   :: forall state
    . (TestingInterface state)
   => RunOptions
+  -> String
+  -- ^ Group name for test ID resolution
+  -> TraceRecorder
+  -- ^ Callback for recording iteration traces
+  -> IO (IORef Int)
+  -- ^ Iteration counter accessor
   -> Property
-negativeTest opts = monadicIO $ do
+negativeTest opts groupName recorder getIterRef = monadicIO $ do
+  -- Bump and read iteration index
+  iterIdx <- run $ do
+    iterRef <- getIterRef
+    idx <- readIORef iterRef
+    modifyIORef iterRef (+ 1)
+    pure idx
+  if trEnabled recorder
+    then negativeTestTraced @state opts groupName recorder iterIdx
+    else negativeTestFast @state opts
+
+-- | Traced path for negative tests: runs 'runActionsTraced', builds traces.
+negativeTestTraced
+  :: forall state
+   . (TestingInterface state)
+  => RunOptions
+  -> String
+  -> TraceRecorder
+  -> Int
+  -> PropertyM IO Property
+negativeTestTraced opts groupName recorder iterIdx = do
+  let RunOptions{mcOptions = Options{coverageRef, params}} = opts
+  -- Phase 1: Run the valid prefix, capturing the final mockchain state
+  (prefixResult, prefixState) <- runTestingMonadT params $ do
+    initialState <- runInitialization @state opts
+
+    (finalState, transitions) <- runActionsTraced opts 10 initialState
+
+    -- Generate an action that VIOLATES the precondition in that state
+    result <- lift $ pick $ do
+      maybeInvalid <- arbitraryAction finalState `suchThatMaybe` (not . precondition finalState)
+      case maybeInvalid of
+        Nothing -> discard -- tell QuickCheck to skip this case
+        Just bad -> pure (bad, finalState)
+    pure (result, transitions)
+
+  -- Phase 2: Run the bad action starting from the state left by the valid prefix
+  case prefixResult of
+    Left err -> do
+      monitor (counterexample $ "Valid prefix failed: " ++ show err)
+      -- Record failed iteration trace
+      let trace =
+            IterationTrace
+              { itIndex = iterIdx
+              , itSeed = 0
+              , itStatus = IterationFailure (formatBalanceTxError err)
+              , itTransitions = []
+              , itThreatModels = []
+              }
+      run $ recordIteration recorder groupName "negative" (toJSON trace)
+      pure (property False)
+    Right ((badAction, finalState), transitions) -> do
+      let monadAction = runExceptT $ unTestingMonadT $ perform finalState badAction
+      result' <- run $ try @SomeException $ runMockchainIO monadAction params prefixState
+      -- We distinguish between validation errors and user errors:
+      -- if the action failed at the off-chain level (e.g. balancing), we discard the test,
+      -- but if it failed after submission (i.e. validator rejection), we count it as a success.
+      let badActionText = T.pack (show badAction)
+          badTransition status =
+            Transition
+              { trStepIndex = length transitions
+              , trAction = badActionText
+              , trStateBefore = toJSON finalState
+              , trStateAfter = toJSON finalState
+              , trTransaction = Nothing
+              , trResult = status
+              }
+      case result' of
+        -- we try another round of bad actions
+        Left ex | discardNegativeTestForUserExceptions @state -> do
+          let trace =
+                IterationTrace
+                  { itIndex = iterIdx
+                  , itSeed = 0
+                  , itStatus = IterationDiscarded (T.pack (show ex))
+                  , itTransitions = transitions <> [badTransition (TransitionFailure (T.pack (show ex)))]
+                  , itThreatModels = []
+                  }
+          run $ recordIteration recorder groupName "negative" (toJSON trace)
+          discard
+        Left ex -> do
+          let trace =
+                IterationTrace
+                  { itIndex = iterIdx
+                  , itSeed = 0
+                  , itStatus = IterationSuccess
+                  , itTransitions = transitions <> [badTransition (TransitionFailure (T.pack (show ex)))]
+                  , itThreatModels = []
+                  }
+          run $ recordIteration recorder groupName "negative" (toJSON trace)
+          pure (property True)
+        Right result ->
+          case result of
+            (Left err, MockChainState{mcsCoverageData = covData}) -> do
+              -- Good: the invalid action failed via BalanceTxError (validator rejection)
+              for_ coverageRef $ \ref -> liftIO $ modifyIORef ref (<> (covData <> coverageFromBalanceTxError err))
+              let trace =
+                    IterationTrace
+                      { itIndex = iterIdx
+                      , itSeed = 0
+                      , itStatus = IterationSuccess
+                      , itTransitions = transitions <> [badTransition (TransitionFailure (formatBalanceTxError err))]
+                      , itThreatModels = []
+                      }
+              run $ recordIteration recorder groupName "negative" (toJSON trace)
+              pure (property True)
+            (Right _, MockChainState{mcsCoverageData = covData}) -> do
+              -- Bad: the invalid action succeeded — contract is too permissive
+              for_ coverageRef $ \ref -> liftIO $ modifyIORef ref (<> covData)
+              monitor (counterexample $ "Expected failure for invalid action but it succeeded")
+              let trace =
+                    IterationTrace
+                      { itIndex = iterIdx
+                      , itSeed = 0
+                      , itStatus = IterationFailure "Invalid action succeeded unexpectedly"
+                      , itTransitions = transitions <> [badTransition (TransitionSuccess T.empty)]
+                      , itThreatModels = []
+                      }
+              run $ recordIteration recorder groupName "negative" (toJSON trace)
+              pure (property False)
+
+-- | Fast path for negative tests: runs 'runActions' (no tracing overhead).
+negativeTestFast
+  :: forall state
+   . (TestingInterface state)
+  => RunOptions
+  -> PropertyM IO Property
+negativeTestFast opts = do
   let RunOptions{mcOptions = Options{coverageRef, params}} = opts
   -- Phase 1: Run the valid prefix, capturing the final mockchain state
   (prefixResult, prefixState) <- runTestingMonadT params $ do
@@ -348,11 +503,12 @@ negativeTest opts = monadicIO $ do
     finalState <- runActions opts 10 initialState
 
     -- Generate an action that VIOLATES the precondition in that state
-    lift $ pick $ do
+    result <- lift $ pick $ do
       maybeInvalid <- arbitraryAction finalState `suchThatMaybe` (not . precondition finalState)
       case maybeInvalid of
-        Nothing -> discard -- tell QuickCheck to skip this case
+        Nothing -> discard
         Just bad -> pure (bad, finalState)
+    pure result
 
   -- Phase 2: Run the bad action starting from the state left by the valid prefix
   case prefixResult of
@@ -362,21 +518,15 @@ negativeTest opts = monadicIO $ do
     Right (badAction, finalState) -> do
       let monadAction = runExceptT $ unTestingMonadT $ perform finalState badAction
       result' <- run $ try @SomeException $ runMockchainIO monadAction params prefixState
-      -- We distinguish between validation errors and user errors:
-      -- if the action failed at the off-chain level (e.g. balancing), we discard the test,
-      -- but if it failed after submission (i.e. validator rejection), we count it as a success.
       case result' of
-        -- we try another round of bad actions
         Left _ | discardNegativeTestForUserExceptions @state -> discard
         Left _ -> pure (property True)
         Right result ->
           case result of
             (Left err, MockChainState{mcsCoverageData = covData}) -> do
-              -- Good: the invalid action failed via BalanceTxError (validator rejection)
               for_ coverageRef $ \ref -> liftIO $ modifyIORef ref (<> (covData <> coverageFromBalanceTxError err))
               pure (property True)
             (Right _, MockChainState{mcsCoverageData = covData}) -> do
-              -- Bad: the invalid action succeeded — contract is too permissive
               for_ coverageRef $ \ref -> liftIO $ modifyIORef ref (<> covData)
               monitor (counterexample $ "Expected failure for invalid action but it succeeded")
               pure (property False)
@@ -389,28 +539,52 @@ positiveTest
   :: forall state
    . (TestingInterface state)
   => RunOptions
+  -> String
+  -- ^ Group name for test ID resolution
   -> Maybe (IO (IORef ThreatModelResults))
   -- ^ IORef for collecting results (Nothing = no threat models, don't collect)
   -> [ThreatModel ()]
   -- ^ Threat models (early-stop on TMFailed)
   -> [ThreatModel ()]
   -- ^ Expected vulnerabilities (never early-stop)
+  -> TraceRecorder
+  -- ^ Callback for recording iteration traces
+  -> IO (IORef Int)
+  -- ^ Iteration counter accessor (bumped each QuickCheck iteration)
   -> Property
-positiveTest opts mGetTmResultsRef tms evs = monadicIO $ do
+positiveTest opts groupName mGetTmResultsRef tms evs recorder getIterRef = monadicIO $ do
+  -- Bump and read iteration index
+  iterIdx <- run $ do
+    iterRef <- getIterRef
+    idx <- readIORef iterRef
+    modifyIORef iterRef (+ 1)
+    pure idx
+  if trEnabled recorder
+    then positiveTestTraced @state opts groupName mGetTmResultsRef tms evs recorder iterIdx
+    else positiveTestFast @state opts mGetTmResultsRef tms evs
+
+-- | Traced path: runs 'runActionsTraced', builds 'IterationTrace', records it.
+positiveTestTraced
+  :: forall state
+   . (TestingInterface state)
+  => RunOptions
+  -> String
+  -> Maybe (IO (IORef ThreatModelResults))
+  -> [ThreatModel ()]
+  -> [ThreatModel ()]
+  -> TraceRecorder
+  -> Int
+  -> PropertyM IO Property
+positiveTestTraced opts groupName mGetTmResultsRef tms evs recorder iterIdx = do
   let RunOptions{mcOptions = Options{coverageRef, params}} = opts
   result <- runTestingMonadT params $ do
     initialState <- runInitialization @state opts
 
-    finalState <- runActions opts 10 initialState
+    (finalState, transitions) <- runActionsTraced opts 10 initialState
 
-    -- Run threat models in isolation
-    -- Note: runThreatModelCheck handles rebalancing failures internally (returns TMSkipped)
-    -- so we don't need to catch exceptions here. Any remaining exception is a genuine bug.
-    -- Once a threat model has failed (TMFailed), we skip running it on subsequent transactions.
     allTxs <- getTxs
     let state0 = initialStateFor params Wallet.initialUTxOs
         envs = threatModelEnvs params (reverse allTxs) state0
-    -- Check which threat models have already failed (from previous QuickCheck iterations)
     existingResults <- case mGetTmResultsRef of
       Just getTmRef -> liftIO $ do
         tmRef <- getTmRef
@@ -419,33 +593,36 @@ positiveTest opts mGetTmResultsRef tms evs = monadicIO $ do
     let isTMFailed (TMFailed _) = True
         isTMFailed _ = False
         alreadyFailed name = any isTMFailed (fromMaybe [] (Map.lookup name existingResults))
-        -- Only filter threat models (tms) for early-stop; expected vulnerabilities (evs) always run
         tmsToRun = filter (not . alreadyFailed . fromMaybe "Unnamed" . getThreatModelName) tms
-        allToRun = tmsToRun <> evs -- evs always run, no filtering
-        -- Run each threat model in an isolated MockchainT context
+        allToRun = tmsToRun <> evs
     tmResultsWithCov <- liftIO $ forM allToRun $ \tm -> do
       let name = fromMaybe "Unnamed" (getThreatModelName tm)
-      (outcome, tmFinalState) <-
-        runMockchainIO (runThreatModelCheck AutoSign tm envs) params state0
-      pure (name, outcome, mcsCoverageData tmFinalState)
+      ((outcome, traceEntries), tmFinalState) <-
+        runMockchainIO (runThreatModelCheckTraced AutoSign tm envs) params state0
+      pure (name, outcome, traceEntries, mcsCoverageData tmFinalState)
 
-    -- Extract just the (name, outcome) pairs for downstream processing
-    let tmResults = [(n, o) | (n, o, _) <- tmResultsWithCov]
-        -- Aggregate coverage from all threat model runs
-        tmCoverage = mconcat [cov | (_, _, cov) <- tmResultsWithCov]
+    let tmResults = [(n, o) | (n, o, _, _) <- tmResultsWithCov]
+        tmTracedResults = [(n, o, entries) | (n, o, entries, _) <- tmResultsWithCov]
+        tmCoverage = mconcat [cov | (_, _, _, cov) <- tmResultsWithCov]
 
-    pure (finalState, tmResults, tmCoverage)
+    pure (finalState, transitions, tmResults, tmTracedResults, tmCoverage)
 
   case result of
     (Left err, MockChainState{mcsCoverageData = covData}) -> do
-      -- Extract and accumulate coverage from the failure
       for_ coverageRef $ \ref -> liftIO $ modifyIORef ref (<> (covData <> coverageFromBalanceTxError err))
+      let trace =
+            IterationTrace
+              { itIndex = iterIdx
+              , itSeed = 0
+              , itStatus = IterationFailure (formatBalanceTxError err)
+              , itTransitions = []
+              , itThreatModels = []
+              }
+      run $ recordIteration recorder groupName "positive" (toJSON trace)
       pure (property False)
-    (Right (finalState, tmResults, tmCoverage), MockChainState{mcsCoverageData = covData}) -> do
+    (Right (finalState, transitions, tmResults, tmTracedResults, tmCoverage), MockChainState{mcsCoverageData = covData}) -> do
       monitor (counterexample $ "Final state: " ++ show finalState)
-      -- accumulate coverage from positive test AND threat model runs
       traverse_ (\ref -> liftIO $ modifyIORef ref (<> covData <> tmCoverage)) coverageRef
-      -- Store threat model results in the shared IORef (if present)
       case mGetTmResultsRef of
         Just getTmResultsRef -> run $ do
           tmRef <- getTmResultsRef
@@ -455,7 +632,75 @@ positiveTest opts mGetTmResultsRef tms evs = monadicIO $ do
               existing
               tmResults
         Nothing -> pure ()
-      pure (property True) -- Positive test passes independently of threat models
+      let tmTraces = toThreatModelTraces tmTracedResults
+          trace =
+            IterationTrace
+              { itIndex = iterIdx
+              , itSeed = 0
+              , itStatus = IterationSuccess
+              , itTransitions = transitions
+              , itThreatModels = tmTraces
+              }
+      run $ recordIteration recorder groupName "positive" (toJSON trace)
+      pure (property True)
+
+-- | Fast path: runs 'runActions' (no UTxO snapshots, no tx summaries, no JSON).
+positiveTestFast
+  :: forall state
+   . (TestingInterface state)
+  => RunOptions
+  -> Maybe (IO (IORef ThreatModelResults))
+  -> [ThreatModel ()]
+  -> [ThreatModel ()]
+  -> PropertyM IO Property
+positiveTestFast opts mGetTmResultsRef tms evs = do
+  let RunOptions{mcOptions = Options{coverageRef, params}} = opts
+  result <- runTestingMonadT params $ do
+    initialState <- runInitialization @state opts
+
+    finalState <- runActions opts 10 initialState
+
+    allTxs <- getTxs
+    let state0 = initialStateFor params Wallet.initialUTxOs
+        envs = threatModelEnvs params (reverse allTxs) state0
+    existingResults <- case mGetTmResultsRef of
+      Just getTmRef -> liftIO $ do
+        tmRef <- getTmRef
+        readIORef tmRef
+      Nothing -> pure Map.empty
+    let isTMFailed (TMFailed _) = True
+        isTMFailed _ = False
+        alreadyFailed name = any isTMFailed (fromMaybe [] (Map.lookup name existingResults))
+        tmsToRun = filter (not . alreadyFailed . fromMaybe "Unnamed" . getThreatModelName) tms
+        allToRun = tmsToRun <> evs
+    tmResultsWithCov <- liftIO $ forM allToRun $ \tm -> do
+      let name = fromMaybe "Unnamed" (getThreatModelName tm)
+      ((outcome, traceEntries), tmFinalState) <-
+        runMockchainIO (runThreatModelCheckTraced AutoSign tm envs) params state0
+      pure (name, outcome, traceEntries, mcsCoverageData tmFinalState)
+
+    let tmResults = [(n, o) | (n, o, _, _) <- tmResultsWithCov]
+        tmCoverage = mconcat [cov | (_, _, _, cov) <- tmResultsWithCov]
+
+    pure (finalState, tmResults, tmCoverage)
+
+  case result of
+    (Left err, MockChainState{mcsCoverageData = covData}) -> do
+      for_ coverageRef $ \ref -> liftIO $ modifyIORef ref (<> (covData <> coverageFromBalanceTxError err))
+      pure (property False)
+    (Right (finalState, tmResults, tmCoverage), MockChainState{mcsCoverageData = covData}) -> do
+      monitor (counterexample $ "Final state: " ++ show finalState)
+      traverse_ (\ref -> liftIO $ modifyIORef ref (<> covData <> tmCoverage)) coverageRef
+      case mGetTmResultsRef of
+        Just getTmResultsRef -> run $ do
+          tmRef <- getTmResultsRef
+          modifyIORef tmRef $ \existing ->
+            foldl'
+              (\m (name, outcome) -> Map.insertWith (<>) name [outcome] m)
+              existing
+              tmResults
+        Nothing -> pure ()
+      pure (property True)
 
 -- | Create a test case for displaying threat model results
 threatModelTestCase
@@ -682,6 +927,147 @@ runAction opts modelState action = do
   lift $ monitor (monitoring modelState' action)
 
   pure modelState'
+
+{- | Like 'runActions' but accumulates a trace of each transition.
+The trace captures the model state before\/after each action and
+a summary of the transaction produced. If an action fails (via
+@ExceptT@ or @MonadFail@), the monad short-circuits and the
+partial trace is lost — use the 'IORef' variant in 'positiveTest'
+for partial-failure capture if needed.
+-}
+runActionsTraced
+  :: (TestingInterface state, MonadIO m)
+  => RunOptions
+  -> Int
+  -> state
+  -> TestingMonadT (PropertyM m) (state, [Transition])
+runActionsTraced opts maxSteps initialState = go 0 initialState []
+ where
+  go stepIdx state acc
+    | stepIdx >= maxSteps = pure (state, reverse acc)
+    | otherwise = do
+        mAction <- lift $ genAction state
+        case mAction of
+          Nothing -> pure (state, reverse acc)
+          Just action -> do
+            let stateBefore = toJSON state
+                actionText = T.pack (show action)
+            -- Snapshot the UTxO and txById map before running the action
+            utxoBefore <- fromLedgerUTxO C.shelleyBasedEra <$> getUtxo
+            txByIdBefore <- mcsTxById <$> getMockChainState
+            -- Run the action (may throw, short-circuiting the monad)
+            newState <- runAction opts state action
+            -- If we get here, the action succeeded
+            mTxSummary <- getLastTxSummary txByIdBefore utxoBefore
+            let transition =
+                  Transition
+                    { trStepIndex = stepIdx
+                    , trAction = actionText
+                    , trStateBefore = stateBefore
+                    , trStateAfter = toJSON newState
+                    , trTransaction = mTxSummary
+                    , trResult = TransitionSuccess (fromMaybe T.empty (mTxSummary >>= txsId))
+                    }
+            go (stepIdx + 1) newState (transition : acc)
+
+{- | Check whether a new transaction appeared in the mockchain since
+the given snapshot, and if so, return a compact summary.
+-}
+getLastTxSummary
+  :: (MonadMockchain C.ConwayEra m)
+  => Map.Map C.TxId (C.Tx C.ConwayEra)
+  -- ^ @mcsTxById@ snapshot taken before the action
+  -> C.UTxO C.ConwayEra
+  -- ^ UTxO snapshot taken before the action
+  -> m (Maybe TxSummary)
+getLastTxSummary txByIdBefore utxoBefore = do
+  st <- getMockChainState
+  let txByIdAfter = mcsTxById st
+      newTxIds = Map.keys (Map.difference txByIdAfter txByIdBefore)
+  case newTxIds of
+    [] -> pure Nothing
+    (txId : _) ->
+      case Map.lookup txId txByIdAfter of
+        Nothing -> pure Nothing
+        Just tx -> pure (Just (summarizeTx tx utxoBefore))
+
+{- | Convert traced threat model results into 'ThreatModelTrace' values
+suitable for inclusion in an 'IterationTrace'.
+
+Each 'ThreatModelCheckEntry' (one per 'Validate' call) produces a
+'ThreatModelTrace' with the actual modifications, original\/modified
+transactions, and outcome.
+-}
+toThreatModelTraces :: [(String, ThreatModelOutcome, [ThreatModelCheckEntry])] -> [ThreatModelTrace]
+toThreatModelTraces results = concatMap go results
+ where
+  go (name, outcome, []) =
+    -- No Validate calls: emit a single lightweight trace with just the outcome
+    [ ThreatModelTrace
+        { tmtName = T.pack name
+        , tmtTargetTxIndex = 0
+        , tmtModifications = []
+        , tmtOriginalTx = emptyTxSummary
+        , tmtModifiedTx = Nothing
+        , tmtOutcome = outcomeToTrace outcome
+        }
+    ]
+  go (name, outcome, entries) =
+    -- One ThreatModelTrace per Validate call
+    [ ThreatModelTrace
+        { tmtName = T.pack name
+        , tmtTargetTxIndex = tmceEnvIndex entry
+        , tmtModifications = renderModifications (tmceModifications entry)
+        , tmtOriginalTx = summarizeTx (tmceOriginalTx entry) (tmceOriginalUtxo entry)
+        , tmtModifiedTx = case tmceModifiedTx entry of
+            Just tx -> Just (summarizeTx tx (tmceModifiedUtxo entry))
+            Nothing -> Nothing
+        , tmtOutcome = outcomeToTrace outcome
+        }
+    | entry <- entries
+    ]
+
+  outcomeToTrace TMPassed = TMTOPassed
+  outcomeToTrace (TMFailed msg) = TMTOFailed (T.pack msg)
+  outcomeToTrace TMSkipped = TMTOSkipped "precondition not met"
+  outcomeToTrace (TMError msg) = TMTOError (T.pack msg)
+
+  renderModifications (TxModifier mods) = map (T.pack . show) mods
+
+  emptyTxSummary =
+    TxSummary
+      { txsId = Nothing
+      , txsInputs = []
+      , txsOutputs = []
+      , txsMint = Nothing
+      , txsFee = 0
+      , txsSigners = []
+      , txsValidRange = Nothing
+      }
+
+{- | Format a 'BalanceTxError' for display in trace output.
+For script execution errors, extracts just the error message and
+the last non-coverage log entry (typically the user's trace message),
+filtering out coverage annotation noise (CoverLocation/CoverBool).
+-}
+formatBalanceTxError :: BalanceTxError C.ConwayEra -> T.Text
+formatBalanceTxError (ABalancingError (ScriptExecutionErr errs)) =
+  T.intercalate "; " $ map formatScriptErr errs
+ where
+  formatScriptErr (_witness, errMsg, logs) =
+    let
+      -- Filter out coverage annotation log messages
+      userLogs = filter (not . isCoverageAnnotation) logs
+      -- Show the last user log (most informative) alongside the error
+      suffix = case userLogs of
+        [] -> ""
+        _ -> " | " <> last userLogs
+     in
+      errMsg <> suffix
+  isCoverageAnnotation msg =
+    "CoverLocation (" `T.isPrefixOf` msg
+      || "CoverBool (" `T.isPrefixOf` msg
+formatBalanceTxError err = T.pack (show err)
 
 -- | Initialize the blockchain and validate the model state
 runInitialization

--- a/src/testing-interface/lib/Convex/TestingInterface/Trace.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface/Trace.hs
@@ -1,0 +1,276 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StrictData #-}
+
+module Convex.TestingInterface.Trace (
+  -- * Test run trace
+  TestRunTrace (..),
+  TestCategory (..),
+
+  -- * Iteration trace
+  IterationTrace (..),
+  IterationStatus (..),
+
+  -- * State transitions
+  Transition (..),
+  TransitionResult (..),
+
+  -- * Transaction summary
+  TxSummary (..),
+  TxInputSummary (..),
+  TxOutputSummary (..),
+
+  -- * Threat model trace
+  ThreatModelTrace (..),
+  ThreatModelTraceOutcome (..),
+) where
+
+import Data.Aeson (ToJSON (..), Value, object, (.=))
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+{- | Complete trace of a test run (one QuickCheck property execution = N iterations).
+Links to the Tasty test tree via 'trtTestId'.
+-}
+data TestRunTrace = TestRunTrace
+  { trtTestId :: !Int
+  -- ^ Tasty test ID (links to the @test_done@ event in the NDJSON stream)
+  , trtTestName :: !Text
+  -- ^ e.g. "Positive tests"
+  , trtPath :: ![Text]
+  -- ^ Tasty test path, e.g. @["MyContract", "Positive tests"]@
+  , trtCategory :: !TestCategory
+  , trtIterations :: ![IterationTrace]
+  }
+  deriving (Eq, Show, Generic)
+
+-- | Whether this test run is a positive or negative test property.
+data TestCategory
+  = Positive
+  | Negative
+  deriving (Eq, Show, Generic)
+
+instance ToJSON TestCategory where
+  toJSON Positive = "positive"
+  toJSON Negative = "negative"
+
+-- | Trace of a single QuickCheck iteration within a test run.
+data IterationTrace = IterationTrace
+  { itIndex :: !Int
+  -- ^ 0-based iteration number
+  , itSeed :: !Int
+  -- ^ QuickCheck seed for reproducibility
+  , itStatus :: !IterationStatus
+  , itTransitions :: ![Transition]
+  -- ^ Ordered sequence of actions performed
+  , itThreatModels :: ![ThreatModelTrace]
+  {- ^ Threat model results applied to this iteration's transactions.
+  Only populated for positive tests.
+  -}
+  }
+  deriving (Eq, Show, Generic)
+
+-- | Outcome of a single iteration.
+data IterationStatus
+  = IterationSuccess
+  | IterationFailure !Text
+  | IterationDiscarded !Text
+  deriving (Eq, Show, Generic)
+
+{- | One step in an iteration: an action was performed, the model state changed,
+and a transaction was (possibly) submitted.
+-}
+data Transition = Transition
+  { trStepIndex :: !Int
+  -- ^ 0-based index within the iteration
+  , trAction :: !Text
+  -- ^ @show@ of the @Action state@ value
+  , trStateBefore :: !Value
+  -- ^ @toJSON@ of the model state before @perform@
+  , trStateAfter :: !Value
+  -- ^ @toJSON@ of the model state after @perform@
+  , trTransaction :: !(Maybe TxSummary)
+  {- ^ The transaction produced, if any. @Nothing@ if @perform@ failed
+  before building a transaction.
+  -}
+  , trResult :: !TransitionResult
+  }
+  deriving (Eq, Show, Generic)
+
+-- | Whether the transaction was successfully submitted to the mockchain.
+data TransitionResult
+  = -- | TxId as text
+    TransitionSuccess !Text
+  | -- | Error description
+    TransitionFailure !Text
+  deriving (Eq, Show, Generic)
+
+{- | Compact representation of a transaction for visualization.
+Values are rendered as text to avoid coupling to cardano-api serialization.
+-}
+data TxSummary = TxSummary
+  { txsId :: !(Maybe Text)
+  -- ^ TxId if submitted successfully, @Nothing@ otherwise
+  , txsInputs :: ![TxInputSummary]
+  , txsOutputs :: ![TxOutputSummary]
+  , txsMint :: !(Maybe Text)
+  -- ^ Rendered mint value, @Nothing@ if no minting
+  , txsFee :: !Integer
+  -- ^ Fee in lovelace
+  , txsSigners :: ![Text]
+  -- ^ Required signer key hashes
+  , txsValidRange :: !(Maybe Text)
+  -- ^ Rendered validity interval
+  }
+  deriving (Eq, Show, Generic)
+
+-- | Summary of a transaction input.
+data TxInputSummary = TxInputSummary
+  { tisUtxo :: !Text
+  -- ^ @"txid#index"@
+  , tisAddress :: !Text
+  -- ^ Bech32 or hex address
+  , tisValue :: !Text
+  -- ^ Rendered value (ada + tokens)
+  }
+  deriving (Eq, Show, Generic)
+
+-- | Summary of a transaction output.
+data TxOutputSummary = TxOutputSummary
+  { tosUtxo :: !Text
+  -- ^ @"txid#index"@ – the UTxO reference for this output
+  , tosAddress :: !Text
+  , tosValue :: !Text
+  , tosDatum :: !(Maybe Text)
+  -- ^ @"inline:\<hash\>"@, @"hash:\<hash\>"@, or @Nothing@
+  }
+  deriving (Eq, Show, Generic)
+
+{- | What happened when a threat model was applied to a specific transaction
+in this iteration.
+-}
+data ThreatModelTrace = ThreatModelTrace
+  { tmtName :: !Text
+  -- ^ Name of the threat model (e.g. "unprotectedScriptOutput")
+  , tmtTargetTxIndex :: !Int
+  -- ^ Index into 'itTransitions' identifying which transaction was targeted
+  , tmtModifications :: ![Text]
+  -- ^ Human-readable descriptions of each modification applied
+  , tmtOriginalTx :: !TxSummary
+  -- ^ The original transaction before modification
+  , tmtModifiedTx :: !(Maybe TxSummary)
+  -- ^ The modified transaction, @Nothing@ if the modification couldn't produce a valid tx body
+  , tmtOutcome :: !ThreatModelTraceOutcome
+  }
+  deriving (Eq, Show, Generic)
+
+-- | Outcome of applying a threat model to a transaction.
+data ThreatModelTraceOutcome
+  = -- | Modified tx was correctly rejected by the ledger (good!)
+    TMTOPassed
+  | -- | Modified tx was ACCEPTED by the ledger (vulnerability found!)
+    TMTOFailed !Text
+  | -- | Couldn't test: rebalancing failed or precondition not met
+    TMTOSkipped !Text
+  | -- | Unexpected error during threat model execution
+    TMTOError !Text
+  deriving (Eq, Show, Generic)
+
+-- ---------------------------------------------------------------------
+-- ToJSON instances
+-- ---------------------------------------------------------------------
+
+instance ToJSON TestRunTrace where
+  toJSON t =
+    object
+      [ "testId" .= trtTestId t
+      , "testName" .= trtTestName t
+      , "path" .= trtPath t
+      , "category" .= trtCategory t
+      , "iterations" .= trtIterations t
+      ]
+
+instance ToJSON IterationTrace where
+  toJSON t =
+    object
+      [ "index" .= itIndex t
+      , "seed" .= itSeed t
+      , "status" .= itStatus t
+      , "transitions" .= itTransitions t
+      , "threatModels" .= itThreatModels t
+      ]
+
+instance ToJSON IterationStatus where
+  toJSON IterationSuccess =
+    object ["status" .= ("success" :: Text)]
+  toJSON (IterationFailure msg) =
+    object ["status" .= ("failure" :: Text), "message" .= msg]
+  toJSON (IterationDiscarded msg) =
+    object ["status" .= ("discarded" :: Text), "message" .= msg]
+
+instance ToJSON Transition where
+  toJSON t =
+    object
+      [ "stepIndex" .= trStepIndex t
+      , "action" .= trAction t
+      , "stateBefore" .= trStateBefore t
+      , "stateAfter" .= trStateAfter t
+      , "transaction" .= trTransaction t
+      , "result" .= trResult t
+      ]
+
+instance ToJSON TransitionResult where
+  toJSON (TransitionSuccess txId) =
+    object ["status" .= ("success" :: Text), "txId" .= txId]
+  toJSON (TransitionFailure err) =
+    object ["status" .= ("failure" :: Text), "error" .= err]
+
+instance ToJSON TxSummary where
+  toJSON t =
+    object
+      [ "id" .= txsId t
+      , "inputs" .= txsInputs t
+      , "outputs" .= txsOutputs t
+      , "mint" .= txsMint t
+      , "fee" .= txsFee t
+      , "signers" .= txsSigners t
+      , "validRange" .= txsValidRange t
+      ]
+
+instance ToJSON TxInputSummary where
+  toJSON t =
+    object
+      [ "utxo" .= tisUtxo t
+      , "address" .= tisAddress t
+      , "value" .= tisValue t
+      ]
+
+instance ToJSON TxOutputSummary where
+  toJSON t =
+    object
+      [ "utxo" .= tosUtxo t
+      , "address" .= tosAddress t
+      , "value" .= tosValue t
+      , "datum" .= tosDatum t
+      ]
+
+instance ToJSON ThreatModelTrace where
+  toJSON t =
+    object
+      [ "name" .= tmtName t
+      , "targetTxIndex" .= tmtTargetTxIndex t
+      , "modifications" .= tmtModifications t
+      , "originalTx" .= tmtOriginalTx t
+      , "modifiedTx" .= tmtModifiedTx t
+      , "outcome" .= tmtOutcome t
+      ]
+
+instance ToJSON ThreatModelTraceOutcome where
+  toJSON TMTOPassed =
+    object ["status" .= ("passed" :: Text)]
+  toJSON (TMTOFailed reason) =
+    object ["status" .= ("failed" :: Text), "reason" .= reason]
+  toJSON (TMTOSkipped reason) =
+    object ["status" .= ("skipped" :: Text), "reason" .= reason]
+  toJSON (TMTOError msg) =
+    object ["status" .= ("error" :: Text), "message" .= msg]

--- a/src/testing-interface/lib/Convex/TestingInterface/Trace.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface/Trace.hs
@@ -20,6 +20,10 @@ module Convex.TestingInterface.Trace (
   TxInputSummary (..),
   TxOutputSummary (..),
 
+  -- * Value representation
+  ValueSummary (..),
+  AssetSummary (..),
+
   -- * Threat model trace
   ThreatModelTrace (..),
   ThreatModelTraceOutcome (..),
@@ -58,8 +62,6 @@ instance ToJSON TestCategory where
 data IterationTrace = IterationTrace
   { itIndex :: !Int
   -- ^ 0-based iteration number
-  , itSeed :: !Int
-  -- ^ QuickCheck seed for reproducibility
   , itStatus :: !IterationStatus
   , itTransitions :: ![Transition]
   -- ^ Ordered sequence of actions performed
@@ -106,15 +108,15 @@ data TransitionResult
   deriving (Eq, Show, Generic)
 
 {- | Compact representation of a transaction for visualization.
-Values are rendered as text to avoid coupling to cardano-api serialization.
+Values are structured JSON for full fidelity.
 -}
 data TxSummary = TxSummary
   { txsId :: !(Maybe Text)
   -- ^ TxId if submitted successfully, @Nothing@ otherwise
   , txsInputs :: ![TxInputSummary]
   , txsOutputs :: ![TxOutputSummary]
-  , txsMint :: !(Maybe Text)
-  -- ^ Rendered mint value, @Nothing@ if no minting
+  , txsMint :: !(Maybe ValueSummary)
+  -- ^ Structured mint value, @Nothing@ if no minting
   , txsFee :: !Integer
   -- ^ Fee in lovelace
   , txsSigners :: ![Text]
@@ -130,8 +132,8 @@ data TxInputSummary = TxInputSummary
   -- ^ @"txid#index"@
   , tisAddress :: !Text
   -- ^ Bech32 or hex address
-  , tisValue :: !Text
-  -- ^ Rendered value (ada + tokens)
+  , tisValue :: !ValueSummary
+  -- ^ Structured value (ada + tokens)
   }
   deriving (Eq, Show, Generic)
 
@@ -140,11 +142,40 @@ data TxOutputSummary = TxOutputSummary
   { tosUtxo :: !Text
   -- ^ @"txid#index"@ – the UTxO reference for this output
   , tosAddress :: !Text
-  , tosValue :: !Text
+  , tosValue :: !ValueSummary
   , tosDatum :: !(Maybe Text)
   -- ^ @"inline:\<hash\>"@, @"hash:\<hash\>"@, or @Nothing@
   }
   deriving (Eq, Show, Generic)
+
+-- | Structured representation of a Cardano value for JSON serialization.
+data ValueSummary = ValueSummary
+  { vsLovelace :: !Integer
+  , vsAssets :: ![AssetSummary]
+  }
+  deriving (Eq, Show, Generic)
+
+data AssetSummary = AssetSummary
+  { asPolicyId :: !Text
+  , asName :: !Text
+  , asQuantity :: !Integer
+  }
+  deriving (Eq, Show, Generic)
+
+instance ToJSON ValueSummary where
+  toJSON v =
+    object
+      [ "lovelace" .= vsLovelace v
+      , "assets" .= vsAssets v
+      ]
+
+instance ToJSON AssetSummary where
+  toJSON a =
+    object
+      [ "policyId" .= asPolicyId a
+      , "name" .= asName a
+      , "quantity" .= asQuantity a
+      ]
 
 {- | What happened when a threat model was applied to a specific transaction
 in this iteration.
@@ -194,7 +225,6 @@ instance ToJSON IterationTrace where
   toJSON t =
     object
       [ "index" .= itIndex t
-      , "seed" .= itSeed t
       , "status" .= itStatus t
       , "transitions" .= itTransitions t
       , "threatModels" .= itThreatModels t

--- a/src/testing-interface/lib/Convex/TestingInterface/Trace.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface/Trace.hs
@@ -185,8 +185,8 @@ data ThreatModelTrace = ThreatModelTrace
   -- ^ Name of the threat model (e.g. "unprotectedScriptOutput")
   , tmtTargetTxIndex :: !Int
   -- ^ Index into 'itTransitions' identifying which transaction was targeted
-  , tmtModifications :: ![Text]
-  -- ^ Human-readable descriptions of each modification applied
+  , tmtModifications :: ![Value]
+  -- ^ Structured JSON descriptions of each modification applied
   , tmtOriginalTx :: !TxSummary
   -- ^ The original transaction before modification
   , tmtModifiedTx :: !(Maybe TxSummary)

--- a/src/testing-interface/lib/Convex/TestingInterface/Trace/TxSummary.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface/Trace/TxSummary.hs
@@ -1,0 +1,178 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Convex.TestingInterface.Trace.TxSummary (
+  summarizeTx,
+  summarizeTxBody,
+  renderAddress,
+  renderValue,
+) where
+
+import Cardano.Api qualified as C
+import Convex.TestingInterface.Trace (
+  TxInputSummary (..),
+  TxOutputSummary (..),
+  TxSummary (..),
+ )
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as TE
+import GHC.Exts (toList)
+
+-- | Summarize a full transaction, resolving inputs from the given UTxO set.
+summarizeTx :: C.Tx C.ConwayEra -> C.UTxO C.ConwayEra -> TxSummary
+summarizeTx tx utxo =
+  let body = C.getTxBody tx
+      txId = C.getTxId body
+      summary = summarizeTxBody body utxo
+   in summary{txsId = Just (C.serialiseToRawBytesHexText txId)}
+
+-- | Summarize a transaction body, resolving inputs from the given UTxO set.
+summarizeTxBody :: C.TxBody C.ConwayEra -> C.UTxO C.ConwayEra -> TxSummary
+summarizeTxBody body (C.UTxO utxoMap) =
+  let content = C.getTxBodyContent body
+
+      -- Inputs (resolved from UTxO)
+      inputTxIns = map fst (C.txIns content)
+      inputs =
+        [ mkInputSummary txIn txOut
+        | txIn <- inputTxIns
+        , Just txOut <- [Map.lookup txIn utxoMap]
+        ]
+
+      -- Outputs
+      outputs = zipWith (mkOutputSummary (C.getTxId body)) [0 ..] (C.txOuts content)
+
+      -- Fee
+      fee = case C.txFee content of
+        C.TxFeeExplicit _ coin -> C.unCoin coin
+
+      -- Mint
+      mint = case C.txMintValue content of
+        C.TxMintNone -> Nothing
+        mv@C.TxMintValue{} ->
+          let v = C.txMintValueToValue mv
+           in if v == mempty then Nothing else Just (renderValue v)
+
+      -- Required signers
+      signers = case C.txExtraKeyWits content of
+        C.TxExtraKeyWitnessesNone -> []
+        C.TxExtraKeyWitnesses _ hashes -> map C.serialiseToRawBytesHexText hashes
+
+      -- Validity range
+      validRange =
+        renderValidityRange
+          (C.txValidityLowerBound content)
+          (C.txValidityUpperBound content)
+   in TxSummary
+        { txsId = Nothing
+        , txsInputs = inputs
+        , txsOutputs = outputs
+        , txsMint = mint
+        , txsFee = fee
+        , txsSigners = signers
+        , txsValidRange = validRange
+        }
+
+-- | Build an input summary from a TxIn and its resolved TxOut.
+mkInputSummary :: C.TxIn -> C.TxOut C.CtxUTxO C.ConwayEra -> TxInputSummary
+mkInputSummary txIn (C.TxOut addr val _datum _refScript) =
+  TxInputSummary
+    { tisUtxo = renderTxIn txIn
+    , tisAddress = renderAddressInEra addr
+    , tisValue = renderValue (C.txOutValueToValue val)
+    }
+
+-- | Build an output summary from a TxId, an index, and a TxOut.
+mkOutputSummary :: C.TxId -> Int -> C.TxOut C.CtxTx C.ConwayEra -> TxOutputSummary
+mkOutputSummary txId idx (C.TxOut addr val datum _refScript) =
+  TxOutputSummary
+    { tosUtxo = renderTxIn (C.TxIn txId (C.TxIx (fromIntegral idx)))
+    , tosAddress = renderAddressInEra addr
+    , tosValue = renderValue (C.txOutValueToValue val)
+    , tosDatum = renderDatum datum
+    }
+
+-- ---------------------------------------------------------------------
+-- Rendering helpers
+-- ---------------------------------------------------------------------
+
+-- | Render a TxIn as @"txid#index"@.
+renderTxIn :: C.TxIn -> Text
+renderTxIn (C.TxIn txId (C.TxIx ix)) =
+  C.serialiseToRawBytesHexText txId <> "#" <> Text.pack (show ix)
+
+-- | Render an AddressInEra as bech32 text.
+renderAddressInEra :: C.AddressInEra C.ConwayEra -> Text
+renderAddressInEra (C.AddressInEra C.ShelleyAddressInEra{} addr) = C.serialiseAddress addr
+renderAddressInEra (C.AddressInEra C.ByronAddressInAnyEra{} addr) = Text.pack (show addr)
+
+-- | Render a Shelley address as bech32 text.
+renderAddress :: C.Address C.ShelleyAddr -> Text
+renderAddress = C.serialiseAddress
+
+{- | Render a Value as human-readable text.
+
+Format: @"1500000 lovelace + 100 \<policyId\>.\<assetName\>"@
+-}
+renderValue :: C.Value -> Text
+renderValue val =
+  let items = toList val
+   in Text.intercalate " + " (map renderAsset items)
+
+-- | Render a single asset entry.
+renderAsset :: (C.AssetId, C.Quantity) -> Text
+renderAsset (C.AdaAssetId, C.Quantity n) =
+  Text.pack (show n) <> " lovelace"
+renderAsset (C.AssetId policyId assetName, C.Quantity n) =
+  Text.pack (show n) <> " " <> renderPolicyId policyId <> "." <> renderAssetName assetName
+
+-- | Render a PolicyId as shortened hex.
+renderPolicyId :: C.PolicyId -> Text
+renderPolicyId pid =
+  let hex = C.serialiseToRawBytesHexText pid
+   in shortenHash hex
+
+-- | Render an AssetName as text, trying UTF-8 decoding first.
+renderAssetName :: C.AssetName -> Text
+renderAssetName an =
+  let C.UnsafeAssetName bs = an
+   in if BS.null bs
+        then "<empty>"
+        else case TE.decodeUtf8' bs of
+          Right t -> t
+          Left _ -> C.serialiseToRawBytesHexText an
+
+-- | Render a datum reference for a transaction output.
+renderDatum :: C.TxOutDatum C.CtxTx C.ConwayEra -> Maybe Text
+renderDatum C.TxOutDatumNone = Nothing
+renderDatum (C.TxOutDatumHash _ h) = Just ("hash:" <> C.serialiseToRawBytesHexText h)
+renderDatum (C.TxOutSupplementalDatum _ d) =
+  Just ("supplemental:" <> C.serialiseToRawBytesHexText (C.hashScriptDataBytes d))
+renderDatum (C.TxOutDatumInline _ d) =
+  Just ("inline:" <> C.serialiseToRawBytesHexText (C.hashScriptDataBytes d))
+
+-- | Render validity range as text. Returns @Nothing@ for unbounded ranges.
+renderValidityRange
+  :: C.TxValidityLowerBound C.ConwayEra
+  -> C.TxValidityUpperBound C.ConwayEra
+  -> Maybe Text
+renderValidityRange lower upper =
+  case (lower, upper) of
+    (C.TxValidityNoLowerBound, C.TxValidityUpperBound _ Nothing) ->
+      Nothing -- unbounded, no need to show
+    _ ->
+      Just (renderLower lower <> " - " <> renderUpper upper)
+ where
+  renderLower C.TxValidityNoLowerBound = "(-inf"
+  renderLower (C.TxValidityLowerBound _ (C.SlotNo n)) = "[" <> Text.pack (show n)
+  renderUpper (C.TxValidityUpperBound _ Nothing) = "+inf)"
+  renderUpper (C.TxValidityUpperBound _ (Just (C.SlotNo n))) = Text.pack (show n) <> ")"
+
+-- | Shorten a hex hash to the first 8 characters.
+shortenHash :: Text -> Text
+shortenHash h
+  | Text.length h > 8 = Text.take 8 h <> "…"
+  | otherwise = h

--- a/src/testing-interface/lib/Convex/TestingInterface/Trace/TxSummary.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface/Trace/TxSummary.hs
@@ -6,6 +6,8 @@ module Convex.TestingInterface.Trace.TxSummary (
   summarizeTxBody,
   renderAddress,
   toValueSummary,
+  renderAssetName,
+  renderDatum,
 ) where
 
 import Cardano.Api qualified as C

--- a/src/testing-interface/lib/Convex/TestingInterface/Trace/TxSummary.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface/Trace/TxSummary.hs
@@ -5,14 +5,16 @@ module Convex.TestingInterface.Trace.TxSummary (
   summarizeTx,
   summarizeTxBody,
   renderAddress,
-  renderValue,
+  toValueSummary,
 ) where
 
 import Cardano.Api qualified as C
 import Convex.TestingInterface.Trace (
+  AssetSummary (..),
   TxInputSummary (..),
   TxOutputSummary (..),
   TxSummary (..),
+  ValueSummary (..),
  )
 import Data.ByteString qualified as BS
 import Data.Map.Strict qualified as Map
@@ -54,7 +56,7 @@ summarizeTxBody body (C.UTxO utxoMap) =
         C.TxMintNone -> Nothing
         mv@C.TxMintValue{} ->
           let v = C.txMintValueToValue mv
-           in if v == mempty then Nothing else Just (renderValue v)
+           in if v == mempty then Nothing else Just (toValueSummary v)
 
       -- Required signers
       signers = case C.txExtraKeyWits content of
@@ -82,7 +84,7 @@ mkInputSummary txIn (C.TxOut addr val _datum _refScript) =
   TxInputSummary
     { tisUtxo = renderTxIn txIn
     , tisAddress = renderAddressInEra addr
-    , tisValue = renderValue (C.txOutValueToValue val)
+    , tisValue = toValueSummary (C.txOutValueToValue val)
     }
 
 -- | Build an output summary from a TxId, an index, and a TxOut.
@@ -91,7 +93,7 @@ mkOutputSummary txId idx (C.TxOut addr val datum _refScript) =
   TxOutputSummary
     { tosUtxo = renderTxIn (C.TxIn txId (C.TxIx (fromIntegral idx)))
     , tosAddress = renderAddressInEra addr
-    , tosValue = renderValue (C.txOutValueToValue val)
+    , tosValue = toValueSummary (C.txOutValueToValue val)
     , tosDatum = renderDatum datum
     }
 
@@ -113,27 +115,24 @@ renderAddressInEra (C.AddressInEra C.ByronAddressInAnyEra{} addr) = Text.pack (s
 renderAddress :: C.Address C.ShelleyAddr -> Text
 renderAddress = C.serialiseAddress
 
-{- | Render a Value as human-readable text.
+-- | Build a structured ValueSummary from a cardano-api Value.
+toValueSummary :: C.Value -> ValueSummary
+toValueSummary val =
+  let items = toList val -- [(AssetId, Quantity)]
+      lovelace = sum [n | (C.AdaAssetId, C.Quantity n) <- items]
+      assets = [toAssetSummary pid name qty | (C.AssetId pid name, C.Quantity qty) <- items]
+   in ValueSummary
+        { vsLovelace = lovelace
+        , vsAssets = assets
+        }
 
-Format: @"1500000 lovelace + 100 \<policyId\>.\<assetName\>"@
--}
-renderValue :: C.Value -> Text
-renderValue val =
-  let items = toList val
-   in Text.intercalate " + " (map renderAsset items)
-
--- | Render a single asset entry.
-renderAsset :: (C.AssetId, C.Quantity) -> Text
-renderAsset (C.AdaAssetId, C.Quantity n) =
-  Text.pack (show n) <> " lovelace"
-renderAsset (C.AssetId policyId assetName, C.Quantity n) =
-  Text.pack (show n) <> " " <> renderPolicyId policyId <> "." <> renderAssetName assetName
-
--- | Render a PolicyId as shortened hex.
-renderPolicyId :: C.PolicyId -> Text
-renderPolicyId pid =
-  let hex = C.serialiseToRawBytesHexText pid
-   in shortenHash hex
+toAssetSummary :: C.PolicyId -> C.AssetName -> Integer -> AssetSummary
+toAssetSummary pid name qty =
+  AssetSummary
+    { asPolicyId = C.serialiseToRawBytesHexText pid -- FULL hex, no truncation
+    , asName = renderAssetName name -- UTF-8 or hex fallback
+    , asQuantity = qty
+    }
 
 -- | Render an AssetName as text, trying UTF-8 decoding first.
 renderAssetName :: C.AssetName -> Text
@@ -170,9 +169,3 @@ renderValidityRange lower upper =
   renderLower (C.TxValidityLowerBound _ (C.SlotNo n)) = "[" <> Text.pack (show n)
   renderUpper (C.TxValidityUpperBound _ Nothing) = "+inf)"
   renderUpper (C.TxValidityUpperBound _ (Just (C.SlotNo n))) = Text.pack (show n) <> ")"
-
--- | Shorten a hex hash to the first 8 characters.
-shortenHash :: Text -> Text
-shortenHash h
-  | Text.length h > 8 = Text.take 8 h <> "…"
-  | otherwise = h

--- a/src/testing-interface/lib/Convex/ThreatModel.hs
+++ b/src/testing-interface/lib/Convex/ThreatModel.hs
@@ -67,6 +67,8 @@ module Convex.ThreatModel (
   runThreatModelM,
   runThreatModelMQuiet,
   runThreatModelCheck,
+  runThreatModelCheckTraced,
+  ThreatModelCheckEntry (..),
   assertThreatModel,
   getThreatModelName,
 
@@ -506,6 +508,92 @@ runThreatModelCheck signingWallet = go False
       MonitorLocal _m k -> checkInterp wallet k -- No Property to wrap; drop monitoring
       Done{} -> go True model envs
       Named _n k -> checkInterp wallet k
+
+-- | A single trace entry from a threat model check against one ThreatModelEnv.
+data ThreatModelCheckEntry = ThreatModelCheckEntry
+  { tmceEnvIndex :: !Int
+  -- ^ Which env (tx) was tested
+  , tmceModifications :: !TxModifier
+  -- ^ The modifications applied
+  , tmceOriginalTx :: !(Tx Era)
+  -- ^ The original transaction
+  , tmceOriginalUtxo :: !(UTxO Era)
+  -- ^ The original UTxO
+  , tmceModifiedTx :: !(Maybe (Tx Era))
+  -- ^ The rebalanced modified tx (Nothing if rebalancing failed)
+  , tmceModifiedUtxo :: !(UTxO Era)
+  -- ^ The modified UTxO
+  , tmceValidation :: !(Maybe ValidityReport)
+  -- ^ Nothing if rebalancing failed (skipped)
+  }
+
+{- | Like 'runThreatModelCheck' but additionally accumulates trace data.
+  Each 'Validate' call in the threat model produces a 'ThreatModelCheckEntry'.
+  Coverage is still accumulated in MockChainState as a side effect.
+-}
+runThreatModelCheckTraced
+  :: (MonadMockchain Era m, MonadFail m, MonadIO m)
+  => SigningWallet
+  -> ThreatModel a
+  -> [ThreatModelEnv]
+  -> m (ThreatModelOutcome, [ThreatModelCheckEntry])
+runThreatModelCheckTraced signingWallet = go False [] 0
+ where
+  go b acc _envIdx _model [] = pure (if b then TMPassed else TMSkipped, reverse acc)
+  go b acc envIdx model (env : envs) = do
+    -- Resolve wallet: use provided or detect from transaction
+    let resolvedWallet = case signingWallet of
+          SignWith w -> Right w
+          AutoSign -> TM.detectSigningWallet (currentTx env)
+    case resolvedWallet of
+      Left err -> pure (TMError err, reverse acc)
+      Right wallet -> checkInterp wallet acc model
+   where
+    checkInterp wallet acc' = \case
+      Validate mods k -> do
+        let (modifiedTx, modifiedUtxo) = applyTxModifier (currentTx env) (currentUTxOs env) mods
+        params <- askNodeParams
+        -- Try rebalancing - failure means this modification can't be tested on this tx
+        rebalanceResult <- TM.rebalanceAndSign wallet modifiedTx modifiedUtxo
+        case rebalanceResult of
+          Left _err -> do
+            let entry =
+                  ThreatModelCheckEntry
+                    { tmceEnvIndex = envIdx
+                    , tmceModifications = mods
+                    , tmceOriginalTx = currentTx env
+                    , tmceOriginalUtxo = currentUTxOs env
+                    , tmceModifiedTx = Nothing
+                    , tmceModifiedUtxo = modifiedUtxo
+                    , tmceValidation = Nothing
+                    }
+            go b (entry : acc') (envIdx + 1) model envs -- Rebalancing failed, skip to next tx
+          Right rebalancedTx -> do
+            (report, covData) <- validateTxM params rebalancedTx modifiedUtxo
+            modifyMockChainState $ \s -> ((), s & coverageData %~ (<> covData))
+            let entry =
+                  ThreatModelCheckEntry
+                    { tmceEnvIndex = envIdx
+                    , tmceModifications = mods
+                    , tmceOriginalTx = currentTx env
+                    , tmceOriginalUtxo = currentUTxOs env
+                    , tmceModifiedTx = Just rebalancedTx
+                    , tmceModifiedUtxo = modifiedUtxo
+                    , tmceValidation = Just report
+                    }
+            checkInterp wallet (entry : acc') (k report)
+      Generate gen _shr k -> do
+        a <- liftIO $ QC.generate gen
+        checkInterp wallet acc' (k a)
+      GetCtx k ->
+        checkInterp wallet acc' (k env)
+      Skip -> go b acc' (envIdx + 1) model envs
+      InPrecondition k -> checkInterp wallet acc' (k False)
+      Fail err -> pure (TMFailed err, reverse acc')
+      Monitor _m k -> checkInterp wallet acc' k
+      MonitorLocal _m k -> checkInterp wallet acc' k
+      Done{} -> go True acc' (envIdx + 1) model envs
+      Named _n k -> checkInterp wallet acc' k
 
 {- | Check a precondition. If the argument threat model fails, the evaluation of the current
   transaction is skipped. If all transactions in an evaluation of `runThreatModel` are skipped

--- a/src/testing-interface/lib/Convex/ThreatModel/TxModifier.hs
+++ b/src/testing-interface/lib/Convex/ThreatModel/TxModifier.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -26,6 +27,10 @@ import Data.Sequence.Strict qualified as Seq
 import Data.Set qualified as Set
 import PlutusLedgerApi.Test.Examples (alwaysSucceedingNAryFunction)
 
+import Data.Aeson (object, (.=))
+import Data.Text qualified as Text
+
+import Convex.TestingInterface.Trace.TxSummary (renderAssetName, renderDatum, toValueSummary)
 import Convex.ThreatModel.Cardano.Api
 
 -- | A transaction output paired with its index in the transaction.
@@ -711,3 +716,124 @@ removeRequiredSigner = txMod . RemoveRequiredSigner
 -}
 replaceTx :: Tx Era -> UTxO Era -> TxModifier
 replaceTx tx utxos = txMod $ ReplaceTx tx utxos
+
+-- ---------------------------------------------------------------------
+-- ToJSON instance for TxMod
+-- ---------------------------------------------------------------------
+
+-- | Render an AddressAny as text (bech32 for Shelley, show for Byron).
+renderAddressAny :: AddressAny -> Text
+renderAddressAny (AddressShelley addr) = serialiseAddress addr
+renderAddressAny (AddressByron addr) = Text.pack (show addr)
+
+-- | Render a Datum (TxOutDatum CtxTx Era) as a JSON-friendly text value.
+renderDatumAny :: Datum -> Maybe Text
+renderDatumAny = renderDatum
+
+instance ToJSON TxMod where
+  toJSON (RemoveInput txIn) =
+    object
+      [ "type" .= ("removeInput" :: Text)
+      , "utxo" .= renderTxIn txIn
+      ]
+  toJSON (RemoveOutput (TxIx ix)) =
+    object
+      [ "type" .= ("removeOutput" :: Text)
+      , "index" .= ix
+      ]
+  toJSON (ChangeOutput (TxIx ix) mAddr mVal mDatum mRefScript) =
+    object
+      [ "type" .= ("changeOutput" :: Text)
+      , "index" .= ix
+      , "address" .= fmap renderAddressAny mAddr
+      , "value" .= fmap toValueSummary mVal
+      , "datum" .= (mDatum >>= renderDatumAny)
+      , "referenceScript" .= fmap (Text.pack . show) mRefScript
+      ]
+  toJSON (ChangeInput txIn mAddr mVal mDatum mRefScript) =
+    object
+      [ "type" .= ("changeInput" :: Text)
+      , "utxo" .= renderTxIn txIn
+      , "address" .= fmap renderAddressAny mAddr
+      , "value" .= fmap toValueSummary mVal
+      , "datum" .= (mDatum >>= renderDatumAny)
+      , "referenceScript" .= fmap (Text.pack . show) mRefScript
+      ]
+  toJSON (ChangeScriptInput txIn mVal mDatum mRedeemer mRefScript) =
+    object
+      [ "type" .= ("changeScriptInput" :: Text)
+      , "utxo" .= renderTxIn txIn
+      , "value" .= fmap toValueSummary mVal
+      , "datum" .= (mDatum >>= renderDatumAny)
+      , "redeemer" .= fmap (Text.pack . show) mRedeemer
+      , "referenceScript" .= fmap (Text.pack . show) mRefScript
+      ]
+  toJSON (ChangeValidityRange mLower mUpper) =
+    object
+      [ "type" .= ("changeValidityRange" :: Text)
+      , "lowerBound" .= fmap (Text.pack . show) mLower
+      , "upperBound" .= fmap (Text.pack . show) mUpper
+      ]
+  toJSON (AddOutput addr val datum refScript) =
+    object
+      [ "type" .= ("addOutput" :: Text)
+      , "address" .= renderAddressAny addr
+      , "value" .= toValueSummary val
+      , "datum" .= renderDatumAny datum
+      , "referenceScript" .= Text.pack (show refScript)
+      ]
+  toJSON (AddInput addr val datum refScript isRef) =
+    object
+      [ "type" .= ("addInput" :: Text)
+      , "address" .= renderAddressAny addr
+      , "value" .= toValueSummary val
+      , "datum" .= renderDatumAny datum
+      , "referenceScript" .= Text.pack (show refScript)
+      , "isReferenceInput" .= isRef
+      ]
+  toJSON (AddReferenceScriptInput scriptHash val datum redeemer) =
+    object
+      [ "type" .= ("addReferenceScriptInput" :: Text)
+      , "scriptHash" .= serialiseToRawBytesHexText scriptHash
+      , "value" .= toValueSummary val
+      , "datum" .= renderDatumAny datum
+      , "redeemer" .= Text.pack (show redeemer)
+      ]
+  toJSON (AddPlutusScriptInput _script val datum redeemer refScript) =
+    object
+      [ "type" .= ("addPlutusScriptInput" :: Text)
+      , "value" .= toValueSummary val
+      , "datum" .= renderDatumAny datum
+      , "redeemer" .= Text.pack (show redeemer)
+      , "referenceScript" .= Text.pack (show refScript)
+      ]
+  toJSON (AddPlutusScriptReferenceInput _script val datum refScript) =
+    object
+      [ "type" .= ("addPlutusScriptReferenceInput" :: Text)
+      , "value" .= toValueSummary val
+      , "datum" .= renderDatumAny datum
+      , "referenceScript" .= Text.pack (show refScript)
+      ]
+  toJSON (AddSimpleScriptInput _script val refScript isRef) =
+    object
+      [ "type" .= ("addSimpleScriptInput" :: Text)
+      , "value" .= toValueSummary val
+      , "referenceScript" .= Text.pack (show refScript)
+      , "isReferenceInput" .= isRef
+      ]
+  toJSON (AddPlutusScriptMint _script assetName qty redeemer) =
+    object
+      [ "type" .= ("addPlutusScriptMint" :: Text)
+      , "assetName" .= renderAssetName assetName
+      , "quantity" .= qty
+      , "redeemer" .= Text.pack (show redeemer)
+      ]
+  toJSON (RemoveRequiredSigner keyHash) =
+    object
+      [ "type" .= ("removeRequiredSigner" :: Text)
+      , "keyHash" .= serialiseToRawBytesHexText keyHash
+      ]
+  toJSON (ReplaceTx _tx _utxo) =
+    object
+      [ "type" .= ("replaceTx" :: Text)
+      ]

--- a/src/testing-interface/test/AikenBankSpec.hs
+++ b/src/testing-interface/test/AikenBankSpec.hs
@@ -88,6 +88,7 @@ import PlutusLedgerApi.Common qualified as PlutusLedgerApi
 import PlutusTx qualified
 import PlutusTx.Builtins qualified as PlutusTx
 
+import Data.Aeson (ToJSON (..))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertFailure, testCase)
@@ -894,6 +895,9 @@ data BankModel = BankModel
   -- ^ Account owner
   }
   deriving stock (Show, Eq)
+
+instance ToJSON BankModel where
+  toJSON = toJSON . show
 
 instance TestingInterface BankModel where
   data Action BankModel

--- a/src/testing-interface/test/AikenHelloWorldSpec.hs
+++ b/src/testing-interface/test/AikenHelloWorldSpec.hs
@@ -316,6 +316,9 @@ data HelloWorldModel = HelloWorldModel
 instance ToJSON HelloWorldModel where
   toJSON = toJSON . show
 
+instance ToJSON HelloWorldMonitoringModel where
+  toJSON = toJSON . show
+
 instance TestingInterface HelloWorldModel where
   -- Actions for CTF Hello World: lock funds and unlock (correct password only)
   data Action HelloWorldModel

--- a/src/testing-interface/test/AikenHelloWorldSpec.hs
+++ b/src/testing-interface/test/AikenHelloWorldSpec.hs
@@ -55,6 +55,7 @@ import Paths_convex_testing_interface qualified as Pkg
 import PlutusTx qualified
 import PlutusTx.Builtins qualified as PlutusTx
 
+import Data.Aeson (ToJSON (..))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.ExpectedFailure (expectFailBecause)
@@ -311,6 +312,9 @@ data HelloWorldModel = HelloWorldModel
   -- ^ The UTxO at the script (for tracking)
   }
   deriving stock (Show, Eq)
+
+instance ToJSON HelloWorldModel where
+  toJSON = toJSON . show
 
 instance TestingInterface HelloWorldModel where
   -- Actions for CTF Hello World: lock funds and unlock (correct password only)

--- a/src/testing-interface/test/AikenKingOfCardanoSpec.hs
+++ b/src/testing-interface/test/AikenKingOfCardanoSpec.hs
@@ -84,6 +84,7 @@ import PlutusLedgerApi.V1 qualified as PV1
 import PlutusTx qualified
 import PlutusTx.Builtins qualified as PlutusTx
 
+import Data.Aeson (ToJSON (..))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.QuickCheck.Monadic (monadicIO, monitor, run)
 import Test.Tasty (TestTree, testGroup)
@@ -721,6 +722,9 @@ data KingModel = KingModel
   -- ^ Whether the competition is closed
   }
   deriving stock (Show, Eq)
+
+instance ToJSON KingModel where
+  toJSON = toJSON . show
 
 instance TestingInterface KingModel where
   -- Actions for King of Cardano: initialize, overthrow, close

--- a/src/testing-interface/test/AikenLendingSpec.hs
+++ b/src/testing-interface/test/AikenLendingSpec.hs
@@ -93,6 +93,7 @@ import PlutusLedgerApi.V1 qualified as PV1
 import PlutusTx qualified
 import PlutusTx.Builtins qualified as PlutusTx
 
+import Data.Aeson (ToJSON (..))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.QuickCheck.Monadic (monadicIO, monitor, run)
 import Test.Tasty (TestTree, testGroup)
@@ -778,6 +779,9 @@ updateFirst _ _ [] = []
 updateFirst p f (x : xs)
   | p x = f x : xs
   | otherwise = x : updateFirst p f xs
+
+instance ToJSON LendingModel where
+  toJSON = toJSON . show
 
 instance TestingInterface LendingModel where
   -- Actions for Lending: request (from any wallet), lend, repay

--- a/src/testing-interface/test/AikenMultisigTreasurySpec.hs
+++ b/src/testing-interface/test/AikenMultisigTreasurySpec.hs
@@ -78,6 +78,7 @@ import PlutusLedgerApi.V1 qualified as PV1
 import PlutusTx qualified
 import PlutusTx.Builtins qualified as PlutusTx
 
+import Data.Aeson (ToJSON (..))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.QuickCheck.Monadic (monadicIO, monitor, run)
 import Test.Tasty (TestTree, testGroup)
@@ -628,6 +629,9 @@ data SignerChoice = Signer1 | Signer2
 signerToWallet :: SignerChoice -> Wallet
 signerToWallet Signer1 = Wallet.w1
 signerToWallet Signer2 = Wallet.w2
+
+instance ToJSON MultisigModel where
+  toJSON = toJSON . show
 
 instance TestingInterface MultisigModel where
   -- Actions for Multisig: initialize, sign, and use

--- a/src/testing-interface/test/AikenMultisigTreasuryV2Spec.hs
+++ b/src/testing-interface/test/AikenMultisigTreasuryV2Spec.hs
@@ -95,6 +95,7 @@ import PlutusLedgerApi.V1 qualified as PV1
 import PlutusTx qualified
 import PlutusTx.Builtins qualified as PlutusTx
 
+import Data.Aeson (ToJSON (..))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.QuickCheck.Monadic (monadicIO, monitor, run)
 import Test.Tasty (TestTree, testGroup)
@@ -657,6 +658,9 @@ data SignerChoice = Signer1 | Signer2
 signerToWallet :: SignerChoice -> Wallet
 signerToWallet Signer1 = Wallet.w1
 signerToWallet Signer2 = Wallet.w2
+
+instance ToJSON MultisigV2Model where
+  toJSON = toJSON . show
 
 instance TestingInterface MultisigV2Model where
   -- Actions for Multisig V2

--- a/src/testing-interface/test/AikenMultisigTreasuryV3Spec.hs
+++ b/src/testing-interface/test/AikenMultisigTreasuryV3Spec.hs
@@ -94,6 +94,7 @@ import PlutusLedgerApi.V1 qualified as PV1
 import PlutusTx qualified
 import PlutusTx.Builtins qualified as PlutusTx
 
+import Data.Aeson (ToJSON (..))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.QuickCheck.Monadic (monadicIO, monitor, run)
 import Test.Tasty (TestTree, testGroup)
@@ -677,6 +678,9 @@ data SignerChoice = Signer1 | Signer2
 signerToWallet :: SignerChoice -> Wallet
 signerToWallet Signer1 = Wallet.w1
 signerToWallet Signer2 = Wallet.w2
+
+instance ToJSON MultisigV3Model where
+  toJSON = toJSON . show
 
 instance TestingInterface MultisigV3Model where
   -- Actions for Multisig V3

--- a/src/testing-interface/test/AikenPingPongSpec.hs
+++ b/src/testing-interface/test/AikenPingPongSpec.hs
@@ -56,6 +56,7 @@ import Convex.ThreatModel.LargeData (largeDataAttackWith)
 import Convex.ThreatModel.LargeValue (largeValueAttackWith)
 import Convex.ThreatModel.UnprotectedScriptOutput (unprotectedScriptOutput)
 import Convex.Wallet.MockWallet qualified as Wallet
+import Data.Aeson (ToJSON (..))
 import Data.Map qualified as Map
 import Paths_convex_testing_interface qualified as Pkg
 import PlutusTx.Builtins (dataToBuiltinData)
@@ -134,6 +135,9 @@ data AikenPingPongModel = AikenPingPongModel
   -- ^ Amount of lovelace locked in the contract
   }
   deriving (Show, Eq)
+
+instance ToJSON AikenPingPongModel where
+  toJSON = toJSON . show
 
 instance TestingInterface AikenPingPongModel where
   data Action AikenPingPongModel

--- a/src/testing-interface/test/AikenPurchaseOfferSpec.hs
+++ b/src/testing-interface/test/AikenPurchaseOfferSpec.hs
@@ -82,6 +82,7 @@ import PlutusTx.Builtins qualified as PlutusTx
 
 import Convex.ThreatModel.LargeData (largeDataAttack)
 import Convex.ThreatModel.TimeBoundManipulation (timeBoundManipulation)
+import Data.Aeson (ToJSON (..))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.QuickCheck.Monadic (monadicIO, monitor, run)
 import Test.Tasty (TestTree, testGroup)
@@ -649,6 +650,9 @@ data PurchaseOfferModel = PurchaseOfferModel
   -- ^ Once fulfilled, sequence is done - no re-initialization allowed
   }
   deriving stock (Show, Eq)
+
+instance ToJSON PurchaseOfferModel where
+  toJSON = toJSON . show
 
 instance TestingInterface PurchaseOfferModel where
   -- Actions for Purchase Offer: create offer and fulfill it

--- a/src/testing-interface/test/AikenSellNftSpec.hs
+++ b/src/testing-interface/test/AikenSellNftSpec.hs
@@ -62,6 +62,7 @@ import Paths_convex_testing_interface qualified as Pkg
 import PlutusLedgerApi.V1 qualified as PV1
 import PlutusTx qualified
 
+import Data.Aeson (ToJSON (..))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertFailure, testCase)
@@ -360,6 +361,9 @@ data SellNftModel = SellNftModel
   -- ^ Active NFT listings (txin + price)
   }
   deriving stock (Show, Eq)
+
+instance ToJSON SellNftModel where
+  toJSON = toJSON . show
 
 instance TestingInterface SellNftModel where
   -- Actions for Sell NFT: list NFTs and buy them

--- a/src/testing-interface/test/AikenTipJarSpec.hs
+++ b/src/testing-interface/test/AikenTipJarSpec.hs
@@ -67,6 +67,7 @@ import PlutusTx qualified
 import PlutusTx.Builtins qualified as PlutusTx
 import PlutusTx.IsData.Class (UnsafeFromData (unsafeFromBuiltinData))
 
+import Data.Aeson (ToJSON (..))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, assertFailure, testCase)
@@ -427,6 +428,9 @@ data TipJarModel = TipJarModel
   -- ^ Once claimed, sequence is done
   }
   deriving stock (Show, Eq)
+
+instance ToJSON TipJarModel where
+  toJSON = toJSON . show
 
 instance TestingInterface TipJarModel where
   -- Actions for TipJar: initialize, add tips, and owner claims

--- a/src/testing-interface/test/AikenTipJarV2Spec.hs
+++ b/src/testing-interface/test/AikenTipJarV2Spec.hs
@@ -75,6 +75,7 @@ import PlutusTx qualified
 import PlutusTx.Builtins qualified as PlutusTx
 import PlutusTx.IsData.Class (UnsafeFromData (unsafeFromBuiltinData))
 
+import Data.Aeson (ToJSON (..))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, assertFailure, testCase)
@@ -412,6 +413,9 @@ data TipJarV2Model = TipJarV2Model
   -- ^ Once claimed, sequence is done
   }
   deriving stock (Show, Eq)
+
+instance ToJSON TipJarV2Model where
+  toJSON = toJSON . show
 
 instance TestingInterface TipJarV2Model where
   -- Actions for TipJar V2: initialize, add tips, and owner claims

--- a/src/testing-interface/test/AikenVestingSpec.hs
+++ b/src/testing-interface/test/AikenVestingSpec.hs
@@ -70,6 +70,7 @@ import Paths_convex_testing_interface qualified as Pkg
 import PlutusTx qualified
 import PlutusTx.Builtins qualified as PlutusTx
 
+import Data.Aeson (ToJSON (..))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertFailure, testCase)
@@ -386,6 +387,9 @@ data VestingModel = VestingModel
   -- ^ Who can claim
   }
   deriving stock (Show, Eq)
+
+instance ToJSON VestingModel where
+  toJSON = toJSON . show
 
 instance TestingInterface VestingModel where
   -- Actions for Vesting: lock funds and unlock (after deadline)

--- a/src/testing-interface/test/PingPongSpec.hs
+++ b/src/testing-interface/test/PingPongSpec.hs
@@ -86,6 +86,7 @@ import Scripts qualified
 import Scripts.PingPong qualified as PingPong
 import Scripts.PingPong.Vulnerable qualified as VulnerablePingPong
 
+import Data.Aeson (ToJSON (..))
 import Test.QuickCheck.Monadic (monadicIO, monitor, run)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.ExpectedFailure (expectFailBecause)
@@ -107,6 +108,9 @@ data PingPongModel = PingPongModel
   , modelInitialized :: Bool
   }
   deriving (Show, Eq)
+
+instance ToJSON PingPong.PingPongState where
+  toJSON = toJSON . show
 
 instance TestingInterface PingPongModel where
   data Action PingPongModel

--- a/src/testing-interface/test/PingPongSpec.hs
+++ b/src/testing-interface/test/PingPongSpec.hs
@@ -118,6 +118,9 @@ instance ToJSON ScriptDatumStyle where
 instance ToJSON PingPongModel where
   toJSON = toJSON . show
 
+instance ToJSON PingPongMonitoringModel where
+  toJSON = toJSON . show
+
 instance TestingInterface PingPongModel where
   data Action PingPongModel
     = StartWithInlineDatum

--- a/src/testing-interface/test/PingPongSpec.hs
+++ b/src/testing-interface/test/PingPongSpec.hs
@@ -112,6 +112,12 @@ data PingPongModel = PingPongModel
 instance ToJSON PingPong.PingPongState where
   toJSON = toJSON . show
 
+instance ToJSON ScriptDatumStyle where
+  toJSON = toJSON . show
+
+instance ToJSON PingPongModel where
+  toJSON = toJSON . show
+
 instance TestingInterface PingPongModel where
   data Action PingPongModel
     = StartWithInlineDatum

--- a/src/use-cases/convex-use-cases.cabal
+++ b/src/use-cases/convex-use-cases.cabal
@@ -69,6 +69,7 @@ test-suite convex-auction-test
     Auction.Validator
 
   build-depends:
+    , aeson
     , base                                         >=4.14.0
     , bytestring
     , cardano-api
@@ -114,6 +115,7 @@ test-suite convex-escrow-test
     Escrow.Validator
 
   build-depends:
+    , aeson
     , base                                         >=4.14.0
     , bytestring
     , cardano-api
@@ -159,6 +161,7 @@ test-suite convex-multiplayerpingpong-test
     MultiPlayerPingPong.Validator
 
   build-depends:
+    , aeson
     , base                                         >=4.14.0
     , bytestring
     , cardano-api
@@ -204,6 +207,7 @@ test-suite convex-vesting-test
     Vesting.Validator
 
   build-depends:
+    , aeson
     , base                                         >=4.14.0
     , cardano-api
     , cardano-ledger-api

--- a/src/use-cases/test/Auction/Spec/Prop.hs
+++ b/src/use-cases/test/Auction/Spec/Prop.hs
@@ -28,6 +28,7 @@ import Convex.Utils (slotToUtcTime, utcTimeToPosixTime)
 import Convex.Wallet (Wallet, verificationKeyHash)
 import Convex.Wallet qualified as MockWallet
 import Convex.Wallet.MockWallet qualified as MockWallet
+import Data.Aeson (ToJSON (..))
 import Data.Foldable (for_)
 import GHC.Generics (Generic)
 import PlutusLedgerApi.Common qualified as PlutusTx
@@ -85,6 +86,9 @@ data AuctionModel = AuctionModel
   -- ^ The current auction UTxO reference
   }
   deriving (Show, Eq, Generic)
+
+instance ToJSON AuctionModel where
+  toJSON = toJSON . show
 
 instance TestingInterface AuctionModel where
   data Action AuctionModel

--- a/src/use-cases/test/Escrow/Spec/Prop.hs
+++ b/src/use-cases/test/Escrow/Spec/Prop.hs
@@ -33,6 +33,7 @@ import Convex.Utxos (toApiUtxo)
 import Convex.Wallet (Wallet, verificationKeyHash)
 import Convex.Wallet qualified as MockWallet
 import Convex.Wallet.MockWallet qualified as MockWallet
+import Data.Aeson (ToJSON (..))
 import Escrow.Scripts (escrowValidatorScript)
 import Escrow.Validator (Action (..), EscrowParams (..), EscrowTarget (..))
 import GHC.Generics (Generic)
@@ -81,6 +82,9 @@ data EscrowModel = EscrowModel
   -- ^ The current locked UTxO reference
   }
   deriving (Show, Eq, Generic)
+
+instance ToJSON EscrowModel where
+  toJSON = toJSON . show
 
 instance TestingInterface EscrowModel where
   data Action EscrowModel

--- a/src/use-cases/test/MultiPlayerPingPong/Spec/Prop.hs
+++ b/src/use-cases/test/MultiPlayerPingPong/Spec/Prop.hs
@@ -33,6 +33,7 @@ import Convex.ThreatModel.UnprotectedScriptOutput (unprotectedScriptOutput)
 import Convex.Utxos (toApiUtxo)
 import Convex.Wallet (Wallet, verificationKeyHash)
 import Convex.Wallet.MockWallet qualified as MockWallet
+import Data.Aeson (ToJSON (..))
 import GHC.Generics (Generic)
 import MultiPlayerPingPong.Scripts (multiPlayerPingPongValidatorScript)
 import MultiPlayerPingPong.Validator (BallState (Pinged, Ponged), MultiPingPongDatum (..), MultiRedeemer (Hit, Stop))
@@ -84,6 +85,9 @@ data MultiPlayerPingPongModel = MultiPlayerPingPongModel
   -- ^ Value locked in script UTxO.
   }
   deriving (Show, Eq, Generic)
+
+instance ToJSON MultiPlayerPingPongModel where
+  toJSON = toJSON . show
 
 instance TestingInterface MultiPlayerPingPongModel where
   data Action MultiPlayerPingPongModel

--- a/src/use-cases/test/Vesting/Spec/Prop.hs
+++ b/src/use-cases/test/Vesting/Spec/Prop.hs
@@ -29,6 +29,7 @@ import Convex.UseCases.Utils (utxosAt)
 import Convex.Utils (slotToUtcTime, utcTimeToPosixTime)
 import Convex.Wallet (Wallet, verificationKeyHash)
 import Convex.Wallet.MockWallet qualified as MockWallet
+import Data.Aeson (ToJSON (..))
 import GHC.Generics (Generic)
 import PlutusLedgerApi.V1 (Lovelace (getLovelace), lovelaceValue, lovelaceValueOf)
 import Test.QuickCheck.Gen qualified as Gen
@@ -100,6 +101,9 @@ fixedScriptHash :: C.ScriptHash
 fixedScriptHash =
   let validator = C.PlutusScript C.plutusScriptVersion (vestingValidatorScript fixedParams)
    in C.hashScript validator
+
+instance ToJSON VestingModel where
+  toJSON = toJSON . show
 
 instance TestingInterface VestingModel where
   data Action VestingModel


### PR DESCRIPTION
Fixes #47 
Fixes #48 

- A new trace module (Convex.TestingInterface.Trace) with the data types for iterations, transitions, transaction summaries, and threat-model traces.
- Traced versions of the runners (runActionsTraced, runThreatModelCheckTraced) that capture state and transactions as they go. UTxOs are snapshotted before each action runs so consumed inputs are still resolvable.
- Aggregated threat-model summaries wired through Tasty options (TMStore / TMRecorder) so the streaming reporter can attach them to test_done events.