### PR TITLE
Use `monitoring` function to add custom properties and statistics

### DIFF
--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -39,7 +39,7 @@ let
     "aarch64-darwin" = defaultHydraJobs;
   };
 
-  hydraJobs = utils.flattenDerivationTree "-" hydraJobsPerSystem.${system};
+  hydraJobs = utils.flattenDerivationTree "-" (hydraJobsPerSystem.${system} or {});
 in
 
 {

--- a/src/testing-interface/lib/Convex/TestingInterface.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface.hs
@@ -154,7 +154,10 @@ class (Show state, Eq state, Show (Action state)) => TestingInterface state wher
   validate :: (MonadIO m) => state -> TestingMonadT m Bool
   validate _ = pure True
 
-  {- | Called after each action to check custom properties.
+  {- | Called after each successful action to wrap the enclosing QuickCheck property.
+  This hook runs only after 'perform' and 'validate' succeed. Use it for
+  property-level checks, labels, and counterexamples that should be attached to
+  valid state transitions.
   Default: no additional checks.
   -}
   monitoring :: state -> Action state -> Property -> Property
@@ -614,7 +617,7 @@ runAction
   => RunOptions
   -> state
   -> Action state
-  -> TestingMonadT m state
+  -> TestingMonadT (PropertyM m) state
 runAction opts modelState action = do
   when (verbose opts) $
     liftIO $
@@ -633,6 +636,8 @@ runAction opts modelState action = do
   valid <- validate modelState'
   unless valid $
     fail "Blockchain state does not match model state"
+
+  lift $ monitor (monitoring modelState' action)
 
   pure modelState'
 

--- a/src/testing-interface/test/AikenHelloWorldSpec.hs
+++ b/src/testing-interface/test/AikenHelloWorldSpec.hs
@@ -417,6 +417,7 @@ instance TestingInterface HelloWorldMonitoringModel where
 
   validate (HelloWorldMonitoringModel model) = validate model
 
+  -- Here is an example of a monitoring function that intentionally fails after the first successful action.
   monitoring (HelloWorldMonitoringModel state) (MonitorHelloWorldAction action) _ =
     QC.counterexample
       ( "HelloWorld monitoring forced failure after action "

--- a/src/testing-interface/test/AikenHelloWorldSpec.hs
+++ b/src/testing-interface/test/AikenHelloWorldSpec.hs
@@ -41,7 +41,7 @@ import Convex.MockChain.CoinSelection (balanceAndSubmit, tryBalanceAndSubmit)
 import Convex.MockChain.Defaults qualified as Defaults
 import Convex.MockChain.Utils (mockchainSucceeds)
 import Convex.TestingInterface (
-  RunOptions,
+  RunOptions (..),
   TestingInterface (..),
   ThreatModelsFor (..),
   propRunActionsWithOptions,
@@ -57,6 +57,7 @@ import PlutusTx.Builtins qualified as PlutusTx
 
 import System.IO.Unsafe (unsafePerformIO)
 import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.ExpectedFailure (expectFailBecause)
 import Test.Tasty.HUnit (assertFailure, testCase)
 import Test.Tasty.QuickCheck ()
 import Test.Tasty.QuickCheck qualified as QC
@@ -393,6 +394,41 @@ instance ThreatModelsFor HelloWorldModel where
   -- No threat models for this simple contract
   threatModels = []
 
+newtype HelloWorldMonitoringModel = HelloWorldMonitoringModel
+  { unHelloWorldMonitoringModel :: HelloWorldModel
+  }
+  deriving stock (Show, Eq)
+
+instance TestingInterface HelloWorldMonitoringModel where
+  data Action HelloWorldMonitoringModel
+    = MonitorHelloWorldAction (Action HelloWorldModel)
+    deriving stock (Show, Eq)
+
+  initialize = HelloWorldMonitoringModel <$> initialize @HelloWorldModel
+
+  arbitraryAction (HelloWorldMonitoringModel model) =
+    MonitorHelloWorldAction <$> arbitraryAction model
+
+  precondition (HelloWorldMonitoringModel model) (MonitorHelloWorldAction action) =
+    precondition model action
+
+  perform (HelloWorldMonitoringModel model) (MonitorHelloWorldAction action) =
+    HelloWorldMonitoringModel <$> perform model action
+
+  validate (HelloWorldMonitoringModel model) = validate model
+
+  monitoring (HelloWorldMonitoringModel state) (MonitorHelloWorldAction action) _ =
+    QC.counterexample
+      ( "HelloWorld monitoring forced failure after action "
+          <> show action
+          <> " with state "
+          <> show state
+      )
+      (QC.property False)
+
+instance ThreatModelsFor HelloWorldMonitoringModel where
+  threatModels = []
+
 -- ----------------------------------------------------------------------------
 -- Test tree
 -- ----------------------------------------------------------------------------
@@ -406,4 +442,10 @@ aikenHelloWorldTests runOpts =
     , propRunActionsWithOptions @HelloWorldModel
         "property-based testing"
         runOpts
+    , expectFailBecause "monitoring regression intentionally fails after the first successful action" $
+        propRunActionsWithOptions @HelloWorldMonitoringModel
+          "property-based testing with failing monitoring"
+          runOpts
+            { maxActions = 1
+            }
     ]

--- a/src/testing-interface/test/PingPongSpec.hs
+++ b/src/testing-interface/test/PingPongSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
@@ -55,7 +56,7 @@ import Convex.MockChain.Defaults qualified as Defaults
 import Convex.NodeParams (ledgerProtocolParameters)
 import Convex.TestingInterface (
   Options (Options, params),
-  RunOptions (mcOptions),
+  RunOptions (..),
   TestingInterface (..),
   ThreatModelsFor (..),
   genAction,
@@ -89,6 +90,7 @@ import Scripts.PingPong.Vulnerable qualified as VulnerablePingPong
 
 import Test.QuickCheck.Monadic (monadicIO, monitor, run)
 import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.ExpectedFailure (expectFailBecause)
 import Test.Tasty.HUnit (testCase)
 import Test.Tasty.QuickCheck (
   Property,
@@ -204,10 +206,47 @@ instance TestingInterface PingPongModel where
             liftIO $ putStrLn "Expected inline datum but got something else"
             pure False
 
-  monitoring _state _action prop = prop
+  -- monitoring _state _action prop = prop
+  monitoring _ (PlayRound action) = QC.label ("action=" <> show action)
 
 instance ThreatModelsFor PingPongModel where
   threatModels = [basicThreatModel, unprotectedScriptOutput, largeValueAttackWith 10, largeDataAttackWith 10]
+  expectedVulnerabilities = []
+
+newtype PingPongMonitoringModel = PingPongMonitoringModel
+  { unPingPongMonitoringModel :: PingPongModel
+  }
+  deriving stock (Show, Eq)
+
+instance TestingInterface PingPongMonitoringModel where
+  data Action PingPongMonitoringModel
+    = MonitorPingPongAction (Action PingPongModel)
+    deriving stock (Show, Eq)
+
+  initialize = PingPongMonitoringModel <$> initialize @PingPongModel
+
+  arbitraryAction (PingPongMonitoringModel model) =
+    MonitorPingPongAction <$> arbitraryAction model
+
+  precondition (PingPongMonitoringModel model) (MonitorPingPongAction action) =
+    precondition model action
+
+  perform (PingPongMonitoringModel model) (MonitorPingPongAction action) =
+    PingPongMonitoringModel <$> perform model action
+
+  validate (PingPongMonitoringModel model) = validate model
+
+  monitoring (PingPongMonitoringModel state) (MonitorPingPongAction action) _ =
+    QC.counterexample
+      ( "PingPong monitoring forced failure after action "
+          <> show action
+          <> " with state "
+          <> show state
+      )
+      (QC.property False)
+
+instance ThreatModelsFor PingPongMonitoringModel where
+  threatModels = []
   expectedVulnerabilities = []
 
 plutusScript :: (C.IsPlutusScriptLanguage lang) => C.PlutusScript lang -> C.Script lang
@@ -644,6 +683,12 @@ pingPongTests opts runOpts =
     , propRunActionsWithOptions @PingPongModel
         "Property-based test with TestingInterface"
         runOpts
+    , expectFailBecause "monitoring regression intentionally fails after the first successful action" $
+        propRunActionsWithOptions @PingPongMonitoringModel
+          "Property-based test with failing monitoring"
+          runOpts
+            { maxActions = 1
+            }
     , testProperty
         "PingPong VULNERABLE to unprotected output redirect"
         (propPingPongVulnerableToOutputRedirect runOpts)

--- a/src/testing-interface/test/PingPongSpec.hs
+++ b/src/testing-interface/test/PingPongSpec.hs
@@ -206,7 +206,7 @@ instance TestingInterface PingPongModel where
             liftIO $ putStrLn "Expected inline datum but got something else"
             pure False
 
-  -- monitoring _state _action prop = prop
+  -- Here is an example of using the monitoring function to label actions in QuickCheck output.
   monitoring _ (PlayRound action) = QC.label ("action=" <> show action)
 
 instance ThreatModelsFor PingPongModel where

--- a/src/testing-interface/test/PingPongSpec.hs
+++ b/src/testing-interface/test/PingPongSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}

--- a/src/testing-interface/test/PingPongSpec.hs
+++ b/src/testing-interface/test/PingPongSpec.hs
@@ -1,13 +1,11 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module PingPongSpec (
@@ -344,7 +342,7 @@ instance TestingInterface PingPongModel where
     checkStyle _ = False
 
   -- Here is an example of using the monitoring function to label actions in QuickCheck output.
-  monitoring _ (PlayRound action) = QC.label ("action=" <> show action)
+  monitoring _ action = QC.label ("action=" <> show action)
 
 instance ThreatModelsFor PingPongModel where
   threatModels =

--- a/src/testing-interface/test/PingPongSpec.hs
+++ b/src/testing-interface/test/PingPongSpec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}

--- a/src/use-cases/test/Auction/Spec/Prop.hs
+++ b/src/use-cases/test/Auction/Spec/Prop.hs
@@ -253,7 +253,7 @@ instance TestingInterface AuctionModel where
 
   validate _am = pure True
 
-  monitoring _ _ = error "monitoring not implemented"
+  monitoring _ _ = id
 
 instance ThreatModelsFor AuctionModel where
   threatModels = [doubleSatisfaction]

--- a/src/use-cases/test/Escrow/Spec/Prop.hs
+++ b/src/use-cases/test/Escrow/Spec/Prop.hs
@@ -205,7 +205,7 @@ instance TestingInterface EscrowModel where
 
   validate _em = pure True
 
-  monitoring _ _ = error "monitoring not implemented"
+  monitoring _ _ = id
 
 instance ThreatModelsFor EscrowModel where
   threatModels =

--- a/src/use-cases/test/MultiPlayerPingPong/Spec/Prop.hs
+++ b/src/use-cases/test/MultiPlayerPingPong/Spec/Prop.hs
@@ -236,7 +236,7 @@ instance TestingInterface MultiPlayerPingPongModel where
 
   validate _ = pure True
 
-  monitoring _ _ = error "monitoring not implemented"
+  monitoring _ _ = id
 
 nextStateForHitTurn :: MultiPlayerPingPongModel -> MultiPlayerPingPongModel
 nextStateForHitTurn m =

--- a/src/use-cases/test/Vesting/Spec/Prop.hs
+++ b/src/use-cases/test/Vesting/Spec/Prop.hs
@@ -221,7 +221,7 @@ instance TestingInterface VestingModel where
       pure $ vm{_curSlot = _curSlot vm + slots}
 
   validate _vm = pure True
-  monitoring _ _ = error "monitoring not implemented"
+  monitoring _ _ = id
 
 instance ThreatModelsFor VestingModel where
   threatModels =


### PR DESCRIPTION
Issue #23: comments and suggestions are welcome! 

This pull request enhances the `TestingInterface` property-based testing framework by improving the monitoring hook, adding regression tests for monitoring failures, and updating example contracts to use the new monitoring mechanism. The changes make it easier to attach property-level checks and counterexamples to valid state transitions, and provide clear examples and tests for both successful and intentionally failing monitoring scenarios.

**Monitoring hook improvements:**

* Updated the `monitoring` hook in the `TestingInterface` typeclass to clarify that it wraps the QuickCheck property only after both `perform` and `validate` succeed, and is intended for property-level checks, labels, and counterexamples on valid state transitions.
* Integrated the `monitoring` hook into the `runAction` function, ensuring it is called after successful actions by lifting it into the property monad. [[1]](diffhunk://#diff-f350314850eafc500ca5410cec7ed22d6350ea9899f08ac3f23f029179e1477dL617-R620) [[2]](diffhunk://#diff-f350314850eafc500ca5410cec7ed22d6350ea9899f08ac3f23f029179e1477dR640-R641)

**Regression tests and examples for monitoring:**

* Added new monitoring model types (`HelloWorldMonitoringModel`, `PingPongMonitoringModel`) in `AikenHelloWorldSpec.hs` and `PingPongSpec.hs` that intentionally fail in their `monitoring` hooks, along with regression tests using `expectFailBecause` to verify that failures are detected as expected. [[1]](diffhunk://#diff-52815c5fe6f599c52a1fae77ea1d4961262be62df2c2b464f273867a8d6faf59R397-R432) [[2]](diffhunk://#diff-52815c5fe6f599c52a1fae77ea1d4961262be62df2c2b464f273867a8d6faf59R446-R451) [[3]](diffhunk://#diff-58953eb4c1473255f43cda851fc67d8a425b292cca47751a85f99120d41b15f8L207-R251) [[4]](diffhunk://#diff-58953eb4c1473255f43cda851fc67d8a425b292cca47751a85f99120d41b15f8R686-R691)
* Provided an example in `PingPongSpec.hs` of using the `monitoring` hook to label actions in QuickCheck output, demonstrating non-failing monitoring usage.

**General improvements and cleanup:**

* Updated contract property tests (`AuctionModel`, `EscrowModel`, `MultiPlayerPingPongModel`, `VestingModel`) to implement the new `monitoring` hook as `id` instead of raising errors, ensuring all models conform to the revised interface. [[1]](diffhunk://#diff-7986a1cd1a4d7a96ff2b15193ec7ca90c61613630517d82cd02ecaf6f9d66752L256-R256) [[2]](diffhunk://#diff-9bd3e02941f928d9391db6639294666ed9a2e6acf5bba7bd41deed1ca6c923dcL208-R208) [[3]](diffhunk://#diff-4af9198f17b09ab1c748804a15b0c7a9597360455b93be10569cce7884eed851L239-R239) [[4]](diffhunk://#diff-4098d4bd74a435ab795990897d4b7f8acdec6ef6e003e36ee8b774816cb94c25L224-R224)
* Minor imports and language pragma cleanups in test files to support new features and maintain consistency. [[1]](diffhunk://#diff-52815c5fe6f599c52a1fae77ea1d4961262be62df2c2b464f273867a8d6faf59L44-R44) [[2]](diffhunk://#diff-52815c5fe6f599c52a1fae77ea1d4961262be62df2c2b464f273867a8d6faf59R60) [[3]](diffhunk://#diff-58953eb4c1473255f43cda851fc67d8a425b292cca47751a85f99120d41b15f8R1) [[4]](diffhunk://#diff-58953eb4c1473255f43cda851fc67d8a425b292cca47751a85f99120d41b15f8L58-R59) [[5]](diffhunk://#diff-58953eb4c1473255f43cda851fc67d8a425b292cca47751a85f99120d41b15f8R93)