### PR TITLE
Adding support for filtering threat models based on user-specified options

### DIFF
--- a/src/tasty-streaming/README.md
+++ b/src/tasty-streaming/README.md
@@ -102,8 +102,9 @@ Behavior notes:
 - Unknown IDs fail fast with a helpful error.
 - For threat-model and expected-vulnerability tests, required prerequisites
   (such as `Positive tests`) are included automatically.
-- In JSON outputs (`--list-tests-json` and `--streaming-json`), filtered runs
-  reindex selected tests to a dense ID range starting at `0`.
+- In JSON outputs (`--list-tests-json` and `--streaming-json`), `--test-id` runs preserve the 
+  original test IDs (so they match the IDs discovered via `--list-tests-json`), which may be 
+  sparse rather than reindexed.
 
 ### Stream test results
 

--- a/src/tasty-streaming/README.md
+++ b/src/tasty-streaming/README.md
@@ -44,6 +44,17 @@ main = withCoverage config $ \opts runOpts ->
   defaultMainStreaming (tests opts runOpts)
 ```
 
+If you need package-specific Tasty ingredients (custom option managers,
+listing modes, etc.), use `defaultMainStreamingWithIngredients` and pass
+them explicitly:
+
+```haskell
+import Convex.Tasty.Streaming (defaultMainStreamingWithIngredients)
+
+main :: IO ()
+main = defaultMainStreamingWithIngredients [myIngredientA, myIngredientB] tests
+```
+
 ### 3. Add the package to `cabal.project`
 
 ```
@@ -68,6 +79,32 @@ Combine with Tasty's `-p` pattern flag to filter:
 cabal test convex-testing-interface-test --test-options="--list-tests-json -p 'ping-pong'"
 ```
 
+### Run selected tests by ID
+
+You can run only specific tests by passing one or more Tasty IDs with
+`--test-id` (comma-separated):
+
+```bash
+cabal test convex-testing-interface-test --test-options="--test-id 0"
+```
+
+```bash
+cabal test convex-testing-interface-test --test-options="--test-id 0,3,7"
+```
+
+Recommended workflow:
+
+1. Use `--list-tests-json` to discover IDs.
+2. Re-run with `--test-id` using the IDs you want.
+
+Behavior notes:
+
+- Unknown IDs fail fast with a helpful error.
+- For threat-model and expected-vulnerability tests, required prerequisites
+  (such as `Positive tests`) are included automatically.
+- In JSON outputs (`--list-tests-json` and `--streaming-json`), filtered runs
+  reindex selected tests to a dense ID range starting at `0`.
+
 ### Stream test results
 
 Run tests with real-time NDJSON output instead of console output:
@@ -80,6 +117,12 @@ Combine with pattern filtering:
 
 ```bash
 cabal test convex-testing-interface-test --test-options="--streaming-json -p 'ping-pong'"
+```
+
+Combine streaming with ID filtering:
+
+```bash
+cabal test convex-testing-interface-test --test-options="--streaming-json --test-id 0,3"
 ```
 
 ## NDJSON Event Schema
@@ -215,6 +258,27 @@ cabal test convex-testing-interface-test \
   | jq -R 'fromjson? // empty | .tests[] | {id, name, path}'
 ```
 
+**Pick IDs, then run only those tests:**
+
+```bash
+# Discover IDs
+cabal test convex-testing-interface-test \
+  --test-options="--list-tests-json" 2>/dev/null \
+  | jq -r -R 'fromjson? // empty | .tests[] | "\(.id)\t\(.name)"'
+
+# Run selected IDs
+cabal test convex-testing-interface-test \
+  --test-options="--test-id 0,3"
+```
+
+**Stream only selected test IDs:**
+
+```bash
+cabal test convex-testing-interface-test \
+  --test-options="--streaming-json --test-id 0,3" 2>/dev/null \
+  | jq -R 'fromjson? // empty'
+```
+
 ## JSON Schema
 
 A [JSON Schema (draft 2020-12)](https://json-schema.org/specification) describing every NDJSON event emitted by the streaming reporter lives at `schema/streaming-events.schema.json` in this package. Use it for VS Code extension type generation, payload validation, or as machine-readable documentation of the event format.
@@ -244,6 +308,7 @@ The `convex-schema-gen` package (in `src/schema-gen/`) defines `ToSchema` orphan
 | Export                     | Type         | Description                                                          |
 |----------------------------|--------------|----------------------------------------------------------------------|
 | `defaultMainStreaming`     | `TestTree -> IO ()` | Drop-in replacement for `defaultMain` with streaming support   |
+| `defaultMainStreamingWithIngredients` | `[Ingredient] -> TestTree -> IO ()` | Same as `defaultMainStreaming`, but prepends custom ingredients before streaming defaults |
 | `streamingJsonReporter`    | `Ingredient` | The `--streaming-json` reporter (real-time NDJSON during test runs)   |
 | `listTestsJsonIngredient`  | `Ingredient` | The `--list-tests-json` manager (test discovery without execution)   |
 | `streamingIngredients`     | `[Ingredient]` | All ingredients combined (listing + JSON discovery + streaming + console) |

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
@@ -3,12 +3,13 @@ module Convex.Tasty.Streaming (
   listTestsJsonIngredient,
   streamingIngredients,
   defaultMainStreaming,
+  defaultMainStreamingWithIngredients,
 ) where
 
 import Control.Concurrent.Async (forConcurrently_)
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Concurrent.STM
-import Control.Monad (when)
+import Control.Monad (unless, when)
 import Convex.Tasty.Streaming.SrcLoc (PackageRootOpt (..), callerPackageRoot)
 import Convex.Tasty.Streaming.TMSummary (
   TMRecorder,
@@ -25,13 +26,19 @@ import Data.ByteString.Lazy.Char8 qualified as BL8
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.IntMap.Strict (IntMap)
 import Data.IntMap.Strict qualified as IntMap
+import Data.IntSet qualified as IntSet
+import Data.Map.Strict qualified as Map
+import Data.Maybe (mapMaybe)
 import Data.Proxy (Proxy (..))
+import Data.Set (Set)
+import Data.Set qualified as Set
 import Data.Tagged (Tagged (..))
 import Data.Text qualified as Text
 import Data.Typeable (Typeable)
 import GHC.Stack (HasCallStack, withFrozenCallStack)
-import System.IO (BufferMode (..), hFlush, hSetBuffering, stdout)
-import Test.Tasty (TestTree, defaultMainWithIngredients, localOption)
+import System.Exit (exitFailure)
+import System.IO (BufferMode (..), hFlush, hPutStrLn, hSetBuffering, stderr, stdout)
+import Test.Tasty (defaultMainWithIngredients, localOption)
 import Test.Tasty.Ingredients (Ingredient (..))
 import Test.Tasty.Ingredients.ConsoleReporter (consoleTestReporter)
 import Test.Tasty.Options (IsOption (..), OptionDescription (..), lookupOption, mkFlagCLParser, safeRead)
@@ -41,7 +48,9 @@ import Test.Tasty.Runners (
   Progress (..),
   Result (..),
   Status (..),
+  TestTree (..),
   listingTests,
+  parseOptions,
  )
 
 -- | Command-line option to enable streaming JSON output
@@ -76,6 +85,45 @@ instance IsOption ListTestsJson where
   optionName = Tagged "list-tests-json"
   optionHelp = Tagged "List all tests as a JSON object and exit without running"
   optionCLParser = mkFlagCLParser mempty (ListTestsJson True)
+
+-- | Command-line option to run only tests whose Tasty IDs are selected.
+newtype TestIdFilter = TestIdFilter [Int]
+  deriving (Eq, Ord, Typeable)
+
+instance Monoid TestIdFilter where
+  mempty = TestIdFilter []
+
+instance Semigroup TestIdFilter where
+  TestIdFilter a <> TestIdFilter b = TestIdFilter (a <> b)
+
+instance IsOption TestIdFilter where
+  defaultValue = TestIdFilter []
+  parseValue raw = TestIdFilter <$> parseTestIds raw
+   where
+    parseTestIds s =
+      let tokens = map trim (splitOn ',' s)
+          nonEmpty = filter (not . null) tokens
+       in traverse parseOne nonEmpty
+    parseOne token =
+      case safeRead token :: Maybe Int of
+        Just n | n >= 0 -> Just n
+        _ -> Nothing
+    splitOn _ [] = []
+    splitOn delim s = case break (== delim) s of
+      (a, []) -> [a]
+      (a, _ : rest) -> a : splitOn delim rest
+    trim = dropWhile (== ' ') . reverse . dropWhile (== ' ') . reverse
+  optionName = Tagged "test-id"
+  optionHelp = Tagged "Run only tests whose Tasty IDs match these values (comma-separated); discover IDs with --list-tests-json"
+
+-- | Internal option carrying filtered->original test ID remapping.
+newtype TestIdRemap = TestIdRemap (Maybe (IntMap Int))
+
+instance IsOption TestIdRemap where
+  defaultValue = TestIdRemap Nothing
+  parseValue = const Nothing
+  optionName = Tagged "test-id-remap"
+  optionHelp = Tagged "internal: filtered-to-original test id remapping"
 
 {- | Internal option carrying a shared 'IORef Bool' that is set to 'True' by
 the streaming reporter when @--streaming-json@ is active.  The
@@ -120,6 +168,7 @@ streamingJsonReporter :: Ingredient
 streamingJsonReporter = TestReporter
   [ Option (Proxy :: Proxy StreamingJson)
   , Option (Proxy :: Proxy NoTrace)
+  , Option (Proxy :: Proxy TestIdRemap)
   , Option (Proxy :: Proxy TMStoreOption)
   , Option (Proxy :: Proxy TMRecorder)
   , Option (Proxy :: Proxy TraceRecorder)
@@ -171,7 +220,10 @@ streamingJsonReporter = TestReporter
         let PackageRootOpt mPkgRoot = lookupOption opts
 
         -- Emit suite_started with full test list
-        let testInfos = map snd $ IntMap.toAscList testMap
+        let TestIdRemap mRemap = lookupOption opts
+            remapId i = maybe i (IntMap.findWithDefault i i) mRemap
+            remapInfo ti = ti{tiId = remapId (tiId ti)}
+            testInfos = map (remapInfo . snd) $ IntMap.toAscList testMap
         emit $ SuiteStarted mPkgRoot testInfos
 
         -- Track results for final summary
@@ -187,7 +239,7 @@ streamingJsonReporter = TestReporter
               _ -> pure ()
 
           -- Emit test_started
-          emit $ TestStarted idx
+          emit $ TestStarted (remapId idx)
 
           -- Wait for completion, emitting progress events along the way
           let waitLoop lastSeen = do
@@ -205,7 +257,7 @@ streamingJsonReporter = TestReporter
                   Left p -> do
                     emit $
                       TestProgress
-                        { epId = idx
+                        { epId = remapId idx
                         , epMessage = Text.pack (progressText p)
                         , epPercent = progressPercent p
                         }
@@ -239,7 +291,7 @@ streamingJsonReporter = TestReporter
                       }
           emit $
             TestDone
-              { edId = idx
+              { edId = remapId idx
               , edOutcome = outcome
               , edDuration = resultTime result
               , edDescription = Text.pack (resultDescription result)
@@ -305,6 +357,7 @@ Activated via @--list-tests-json@.
 listTestsJsonIngredient :: Ingredient
 listTestsJsonIngredient = TestManager
   [ Option (Proxy :: Proxy ListTestsJson)
+  , Option (Proxy :: Proxy TestIdRemap)
   , Option (Proxy :: Proxy PackageRootOpt)
   ]
   $ \opts tree -> do
@@ -314,14 +367,73 @@ listTestsJsonIngredient = TestManager
       else Just $ do
         hSetBuffering stdout LineBuffering
         let PackageRootOpt mPkgRoot = lookupOption opts
+            TestIdRemap mRemap = lookupOption opts
+            remapId i = maybe i (IntMap.findWithDefault i i) mRemap
+            remapInfo ti = ti{tiId = remapId (tiId ti)}
         testMap <- buildTestMap opts tree
-        let testInfos = map snd $ IntMap.toAscList testMap
+        let testInfos = map (remapInfo . snd) $ IntMap.toAscList testMap
         emitEvent $ SuiteStarted mPkgRoot testInfos
         pure True
 
+-- | Option ingredient for selecting a subset of tests by Tasty ID.
+testIdFilterIngredient :: Ingredient
+testIdFilterIngredient =
+  TestManager
+    [Option (Proxy :: Proxy TestIdFilter)]
+    (\_ _ -> Nothing)
+
 -- | Default ingredients with streaming reporter added
 streamingIngredients :: [Ingredient]
-streamingIngredients = [listingTests, listTestsJsonIngredient, streamingJsonReporter, consoleTestReporter]
+streamingIngredients = [listingTests, testIdFilterIngredient, listTestsJsonIngredient, streamingJsonReporter, consoleTestReporter]
+
+filterTreeByPaths :: Set [String] -> TestTree -> Maybe TestTree
+filterTreeByPaths selected = go []
+ where
+  go path tree = case tree of
+    SingleTest name _t ->
+      let fullPath = path <> [name]
+       in if fullPath `Set.member` selected
+            then Just tree
+            else Nothing
+    TestGroup name children ->
+      let childPath = path <> [name]
+          keptChildren = mapMaybe (go childPath) children
+       in if null keptChildren
+            then Nothing
+            else Just (TestGroup name keptChildren)
+    PlusTestOptions f subtree ->
+      fmap (PlusTestOptions f) (go path subtree)
+    WithResource spec mkTree ->
+      Just (WithResource spec (\ioRes -> maybe (TestGroup "filtered-out" []) id (go path (mkTree ioRes))))
+    AskOptions k ->
+      Just (AskOptions (\opts -> maybe (TestGroup "filtered-out" []) id (go path (k opts))))
+    After dep expr subtree ->
+      fmap (After dep expr) (go path subtree)
+
+expandSelectedTestIds :: IntMap TestInfo -> IntSet.IntSet -> IntSet.IntSet
+expandSelectedTestIds testMap selectedIds =
+  IntSet.union selectedIds prerequisiteIds
+ where
+  pathToId =
+    Map.fromList
+      [ (tiPath ti <> [tiName ti], tiId ti)
+      | ti <- IntMap.elems testMap
+      ]
+  prerequisiteIds =
+    IntSet.fromList
+      [ positiveId
+      | selectedId <- IntSet.toList selectedIds
+      , Just positiveId <- [positiveTestIdFor selectedId]
+      ]
+  positiveTestIdFor selectedId = do
+    ti <- IntMap.lookup selectedId testMap
+    case tiPath ti of
+      [] -> Nothing
+      groupPath
+        | last groupPath == Text.pack "Threat models"
+            || last groupPath == Text.pack "Expected vulnerabilities" ->
+            Map.lookup (init groupPath <> [Text.pack "Positive tests"]) pathToId
+        | otherwise -> Nothing
 
 {- | Drop-in replacement for 'defaultMain' that supports @--streaming-json@.
 
@@ -357,7 +469,19 @@ be extracted), @packageRoot@ is omitted from the JSON output (consistent
 with the existing @Maybe@-as-absent-key convention).
 -}
 defaultMainStreaming :: (HasCallStack) => TestTree -> IO ()
-defaultMainStreaming tree = do
+defaultMainStreaming = defaultMainStreamingWithIngredients []
+
+{- | Variant of 'defaultMainStreaming' that allows callers to prepend
+additional ingredients (e.g. package-specific CLI option managers).
+
+The same internal streaming wiring is always installed (threat-model
+summary store, trace recorder, shared output lock, and package root
+capture from call-site), then Tasty runs with:
+
+@extraIngredients <> streamingIngredients@
+-}
+defaultMainStreamingWithIngredients :: (HasCallStack) => [Ingredient] -> TestTree -> IO ()
+defaultMainStreamingWithIngredients extraIngredients tree = do
   -- Capture the package root from the user's call site BEFORE doing any
   -- other work. 'withFrozenCallStack' freezes our caller's call stack so
   -- that inside 'callerPackageRoot' the top frame is the user's Main.hs
@@ -367,6 +491,7 @@ defaultMainStreaming tree = do
   let pkgRootOpt = PackageRootOpt (fmap Text.pack mPkgRoot)
   store <- newTMStore
   testMapRef <- newIORef IntMap.empty
+  testIdRemapRef <- newIORef IntMap.empty
   enabledRef <- newIORef False -- set to True by the reporter when --streaming-json is active
   -- Create a single shared output lock used by both the streaming reporter
   -- and the TraceRecorder so their NDJSON lines never interleave.
@@ -387,15 +512,17 @@ defaultMainStreaming tree = do
               when enabled $ do
                 testMap <- readIORef testMapRef
                 let testId = findTestId testMap group category
+                remap <- readIORef testIdRemapRef
+                let mappedId = IntMap.findWithDefault testId testId remap
                 withMVar outputLock $ \_ ->
                   emitEvent $
                     TestTrace
-                      { ettTestId = testId
+                      { ettTestId = mappedId
                       , ettCategory = Text.pack category
                       , ettTrace = iterationJson
                       }
           }
-  let tree' =
+  let baseTree =
         localOption pkgRootOpt $
           localOption (TMStoreOption (Just store)) $
             localOption (storeRecorder store) $
@@ -403,4 +530,39 @@ defaultMainStreaming tree = do
                 localOption (StreamingEnabledRef (Just enabledRef)) $
                   localOption (OutputLockRef (Just outputLock)) $
                     localOption traceRec tree
-  defaultMainWithIngredients streamingIngredients tree'
+
+  opts <- parseOptions (extraIngredients <> streamingIngredients) baseTree
+  let TestIdFilter requested = lookupOption opts
+      requestedIdSet = IntSet.fromList requested
+
+  tree' <-
+    if IntSet.null requestedIdSet
+      then pure baseTree
+      else do
+        fullMap <- buildTestMap opts baseTree
+        let unknown = IntSet.toAscList $ IntSet.difference requestedIdSet (IntSet.fromList (IntMap.keys fullMap))
+        unless (null unknown) $ do
+          hPutStrLn stderr $ "Unknown test id(s) for --test-id: " <> show unknown
+          hPutStrLn stderr "Use --list-tests-json to discover valid test IDs for this suite."
+          exitFailure
+
+        let selectedIdSet = expandSelectedTestIds fullMap requestedIdSet
+            selectedIds = IntSet.toAscList selectedIdSet
+            selectedInfos = map (fullMap IntMap.!) selectedIds
+            selectedPaths =
+              Set.fromList
+                [ map Text.unpack (tiPath ti <> [tiName ti])
+                | ti <- selectedInfos
+                ]
+            remap = IntMap.fromAscList (zip [0 ..] selectedIds)
+
+        writeIORef testIdRemapRef remap
+
+        case filterTreeByPaths selectedPaths baseTree of
+          Nothing -> do
+            hPutStrLn stderr "No tests remained after applying --test-id selection."
+            exitFailure
+          Just filteredTree ->
+            pure $ localOption (TestIdRemap (Just remap)) filteredTree
+
+  defaultMainWithIngredients (extraIngredients <> streamingIngredients) tree'

--- a/src/testing-interface/README.md
+++ b/src/testing-interface/README.md
@@ -132,11 +132,27 @@ threat models include:
 ### 4. Write Properties and Run Tests
 
 ```haskell
+import Convex.TestingInterface (defaultMainTestingInterface, propRunActions)
+import Test.Tasty (testGroup)
+
 main :: IO ()
-main = defaultMain $ testGroup "My Contract"
-  [ propRunActions @MyContractState "testing interface"
-  ]
+main =
+  defaultMainTestingInterface $
+    testGroup "My Contract"
+      [ propRunActions @MyContractState "testing interface"
+      ]
 ```
+
+Use `defaultMainTestingInterface` instead of `defaultMain`.
+It prepares the testing-interface runtime with package-specific options and enables
+streaming support from `convex-tasty-streaming`.
+
+This enables CLI options such as:
+
+- `--list-threat-models`
+- `--list-threat-models-json`
+- `--threat-model-name`
+- streaming options like `--streaming-json` and `--list-tests-json`
 
 `propRunActions` requires the `ThreatModelsFor` constraint. It automatically creates
 a test group containing:

--- a/src/testing-interface/README.md
+++ b/src/testing-interface/README.md
@@ -152,6 +152,34 @@ For custom options (verbosity, max actions, etc.):
 propRunActionsWithOptions @MyContractState "testing interface" myRunOptions
 ```
 
+In this repository test suite, you can filter which threat models run from the CLI:
+
+**Step 1: Discover available threat models:**
+
+```bash
+cabal test convex-testing-interface-test --test-options='--list-threat-models'
+```
+
+This prints all available threat model names (one per line), which you can then copy/paste.
+
+**Step 2: Run one or more threat models:**
+
+```bash
+# Single threat model
+cabal test convex-testing-interface-test --test-options='--threat-model-name "Input Duplication" -p lending'
+
+# Multiple threat models (comma-separated)
+cabal test convex-testing-interface-test --test-options='--threat-model-name "Input Duplication, Unprotected Script Output" -p lending'
+```
+
+Notes:
+
+- Matching is prefix-based and case-sensitive.
+- For multiple threat models, use comma-separated values: `--threat-model-name "TM1, TM2, TM3"`
+- This filter applies only to `threatModels` and does not affect `expectedVulnerabilities`.
+- Threat model execution still happens during `Positive tests`, so this option narrows execution but does not decouple it from the positive-test phase.
+- Empty filter (no `--threat-model-name` option) runs all threat models (default behavior).
+
 ## Architecture
 
 ### Core Types

--- a/src/testing-interface/convex-testing-interface.cabal
+++ b/src/testing-interface/convex-testing-interface.cabal
@@ -42,6 +42,7 @@ library
   import:          lang
   exposed-modules:
     Convex.TestingInterface
+    Convex.TestingInterface.Options
     Convex.TestingInterface.Trace
     Convex.TestingInterface.Trace.TxSummary
     Convex.ThreatModel
@@ -90,6 +91,7 @@ library
     , prettyprinter
     , QuickCheck
     , sop-extras
+    , tagged
     , tasty
     , tasty-expected-failure
     , tasty-hunit

--- a/src/testing-interface/lib/Convex/TestingInterface.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface.hs
@@ -108,7 +108,7 @@ import Data.Aeson.Key qualified as Key
 import Data.ByteString.Lazy.Char8 qualified as LBS
 import Data.Foldable (foldl', for_, traverse_)
 import Data.IORef (IORef, modifyIORef, newIORef, readIORef)
-import Data.List (deleteFirstsBy)
+import Data.List (deleteFirstsBy, isPrefixOf)
 import Data.Map qualified as Map
 import Data.Maybe (fromMaybe)
 
@@ -295,6 +295,11 @@ data RunOptions = RunOptions
   {- ^ If @Just reason@, negative tests are skipped (shown as IGNORED) with the given reason.
   If @Nothing@, negative tests run normally. Default: @Nothing@.
   -}
+  , threatModelFilter :: [String]
+  {- ^ If non-empty, run only threat models whose names start with any value in this list.
+  This filter applies only to 'threatModels' and not to 'expectedVulnerabilities'.
+  If empty, all threat models run. Default: @[]@.
+  -}
   }
 
 defaultRunOptions :: RunOptions
@@ -304,6 +309,7 @@ defaultRunOptions =
     , maxActions = 10
     , mcOptions = defaultOptions
     , disableNegativeTesting = Nothing
+    , threatModelFilter = []
     }
 
 {- | Main property for testing a testing interface.
@@ -578,7 +584,7 @@ positiveTestTraced
   -> Int
   -> PropertyM IO Property
 positiveTestTraced opts groupName mGetTmResultsRef tms evs recorder iterIdx = do
-  let RunOptions{mcOptions = Options{coverageRef, params}} = opts
+  let RunOptions{mcOptions = Options{coverageRef, params}, threatModelFilter} = opts
   result <- runTestingMonadT params $ do
     initialState <- runInitialization @state opts
 
@@ -595,7 +601,25 @@ positiveTestTraced opts groupName mGetTmResultsRef tms evs recorder iterIdx = do
     let isTMFailed (TMFailed _) = True
         isTMFailed _ = False
         alreadyFailed name = any isTMFailed (fromMaybe [] (Map.lookup name existingResults))
-        tmsToRun = filter (not . alreadyFailed . fromMaybe "Unnamed" . getThreatModelName) tms
+
+        matchesThreatModelFilter tm =
+          case threatModelFilter of
+            [] -> True -- empty list: run all threat models
+            names ->
+              -- fromMaybe "Unnamed" (getThreatModelName tm) `elem` names
+              let tmName = fromMaybe "Unnamed" (getThreatModelName tm)
+               in any (`isPrefixOf` tmName) names
+
+        -- Only filter threat models (tms) for early-stop and optional name filtering;
+        -- expected vulnerabilities (evs) always run.
+        tmsToRun =
+          filter
+            ( \tm ->
+                let name = fromMaybe "Unnamed" (getThreatModelName tm)
+                 in matchesThreatModelFilter tm && not (alreadyFailed name)
+            )
+            tms
+
         allToRun = tmsToRun <> evs
     tmResultsWithCov <- liftIO $ forM allToRun $ \tm -> do
       let name = fromMaybe "Unnamed" (getThreatModelName tm)
@@ -654,7 +678,7 @@ positiveTestFast
   -> [ThreatModel ()]
   -> PropertyM IO Property
 positiveTestFast opts mGetTmResultsRef tms evs = do
-  let RunOptions{mcOptions = Options{coverageRef, params}} = opts
+  let RunOptions{mcOptions = Options{coverageRef, params}, threatModelFilter} = opts
   result <- runTestingMonadT params $ do
     initialState <- runInitialization @state opts
 
@@ -671,7 +695,25 @@ positiveTestFast opts mGetTmResultsRef tms evs = do
     let isTMFailed (TMFailed _) = True
         isTMFailed _ = False
         alreadyFailed name = any isTMFailed (fromMaybe [] (Map.lookup name existingResults))
-        tmsToRun = filter (not . alreadyFailed . fromMaybe "Unnamed" . getThreatModelName) tms
+
+        matchesThreatModelFilter tm =
+          case threatModelFilter of
+            [] -> True -- empty list: run all threat models
+            names ->
+              -- fromMaybe "Unnamed" (getThreatModelName tm) `elem` names
+              let tmName = fromMaybe "Unnamed" (getThreatModelName tm)
+               in any (`isPrefixOf` tmName) names
+
+        -- Only filter threat models (tms) for early-stop and optional name filtering;
+        -- expected vulnerabilities (evs) always run.
+        tmsToRun =
+          filter
+            ( \tm ->
+                let name = fromMaybe "Unnamed" (getThreatModelName tm)
+                 in matchesThreatModelFilter tm && not (alreadyFailed name)
+            )
+            tms
+
         allToRun = tmsToRun <> evs
     tmResultsWithCov <- liftIO $ forM allToRun $ \tm -> do
       let name = fromMaybe "Unnamed" (getThreatModelName tm)

--- a/src/testing-interface/lib/Convex/TestingInterface.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface.hs
@@ -314,6 +314,17 @@ defaultRunOptions =
     , threatModelFilter = []
     }
 
+filterThreatModelsByOptions :: RunOptions -> [ThreatModel ()] -> [ThreatModel ()]
+filterThreatModelsByOptions RunOptions{threatModelFilter} =
+  filter matchesThreatModelFilter
+ where
+  matchesThreatModelFilter tm =
+    case threatModelFilter of
+      [] -> True
+      names ->
+        let tmName = fromMaybe "Unnamed" (getThreatModelName tm)
+         in any (`isPrefixOf` tmName) names
+
 {- | Main property for testing a testing interface.
 Generates random action sequences and checks that the implementation matches the model.
 -}
@@ -333,6 +344,7 @@ propRunActionsWithOptions groupName opts =
     withSrcLoc $
       askOption $ \(recorder :: TraceRecorder) ->
         let tms = threatModels @state
+            filteredTms = filterThreatModelsByOptions opts tms
             evs = expectedVulnerabilities @state
          in if null tms && null evs
               then
@@ -350,10 +362,10 @@ propRunActionsWithOptions groupName opts =
                   withResource (newIORef (0 :: Int)) (\_ -> pure ()) $ \getPosRef ->
                     withResource (newIORef (0 :: Int)) (\_ -> pure ()) $ \getNegRef ->
                       sequentialTestGroup groupName AllFinish $
-                        [ testProperty "Positive tests" (positiveTest @state opts groupName (Just getTmResultsRef) tms evs recorder getPosRef)
+                        [ testProperty "Positive tests" (positiveTest @state opts groupName (Just getTmResultsRef) filteredTms evs recorder getPosRef)
                         , negativeTestTree recorder getNegRef
                         ]
-                          <> threatModelGroup getTmResultsRef tms
+                          <> threatModelGroup getTmResultsRef filteredTms
                           <> expectedVulnGroup getTmResultsRef evs
  where
   negativeTestTree recorder getNegRef = case disableNegativeTesting opts of
@@ -586,7 +598,7 @@ positiveTestTraced
   -> Int
   -> PropertyM IO Property
 positiveTestTraced opts groupName mGetTmResultsRef tms evs recorder iterIdx = do
-  let RunOptions{mcOptions = Options{coverageRef, params}, threatModelFilter} = opts
+  let RunOptions{mcOptions = Options{coverageRef, params}} = opts
   result <- runTestingMonadT params $ do
     initialState <- runInitialization @state opts
 
@@ -604,22 +616,15 @@ positiveTestTraced opts groupName mGetTmResultsRef tms evs recorder iterIdx = do
         isTMFailed _ = False
         alreadyFailed name = any isTMFailed (fromMaybe [] (Map.lookup name existingResults))
 
-        matchesThreatModelFilter tm =
-          case threatModelFilter of
-            [] -> True -- empty list: run all threat models
-            names ->
-              let tmName = fromMaybe "Unnamed" (getThreatModelName tm)
-               in any (`isPrefixOf` tmName) names
-
         -- Only filter threat models (tms) for early-stop and optional name filtering;
         -- expected vulnerabilities (evs) always run.
         tmsToRun =
           filter
             ( \tm ->
                 let name = fromMaybe "Unnamed" (getThreatModelName tm)
-                 in matchesThreatModelFilter tm && not (alreadyFailed name)
+                 in not (alreadyFailed name)
             )
-            tms
+            (filterThreatModelsByOptions opts tms)
 
         allToRun = tmsToRun <> evs
     tmResultsWithCov <- liftIO $ forM allToRun $ \tm -> do
@@ -679,7 +684,7 @@ positiveTestFast
   -> [ThreatModel ()]
   -> PropertyM IO Property
 positiveTestFast opts mGetTmResultsRef tms evs = do
-  let RunOptions{mcOptions = Options{coverageRef, params}, threatModelFilter} = opts
+  let RunOptions{mcOptions = Options{coverageRef, params}} = opts
   result <- runTestingMonadT params $ do
     initialState <- runInitialization @state opts
 
@@ -697,22 +702,15 @@ positiveTestFast opts mGetTmResultsRef tms evs = do
         isTMFailed _ = False
         alreadyFailed name = any isTMFailed (fromMaybe [] (Map.lookup name existingResults))
 
-        matchesThreatModelFilter tm =
-          case threatModelFilter of
-            [] -> True -- empty list: run all threat models
-            names ->
-              let tmName = fromMaybe "Unnamed" (getThreatModelName tm)
-               in any (`isPrefixOf` tmName) names
-
         -- Only filter threat models (tms) for early-stop and optional name filtering;
         -- expected vulnerabilities (evs) always run.
         tmsToRun =
           filter
             ( \tm ->
                 let name = fromMaybe "Unnamed" (getThreatModelName tm)
-                 in matchesThreatModelFilter tm && not (alreadyFailed name)
+                 in not (alreadyFailed name)
             )
-            tms
+            (filterThreatModelsByOptions opts tms)
 
         allToRun = tmsToRun <> evs
     tmResultsWithCov <- liftIO $ forM allToRun $ \tm -> do

--- a/src/testing-interface/lib/Convex/TestingInterface.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface.hs
@@ -24,6 +24,7 @@ module Convex.TestingInterface (
   propRunActionsWithOptions,
   RunOptions (..),
   defaultRunOptions,
+  defaultMainTestingInterface,
   genAction,
   runActions,
 
@@ -87,6 +88,7 @@ import Convex.MonadLog (MonadLog)
 import Convex.NodeParams (NodeParams (..))
 import Convex.Tasty.Streaming.SrcLoc (withSrcLoc)
 import Convex.Tasty.Streaming.TMSummary (TMRecorder, ThreatModelSummary (..), TraceRecorder (..), tmRecord)
+import Convex.TestingInterface.Options (defaultMainTestingInterface)
 import Convex.TestingInterface.Trace (
   IterationStatus (..),
   IterationTrace (..),

--- a/src/testing-interface/lib/Convex/TestingInterface.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface.hs
@@ -606,7 +606,6 @@ positiveTestTraced opts groupName mGetTmResultsRef tms evs recorder iterIdx = do
           case threatModelFilter of
             [] -> True -- empty list: run all threat models
             names ->
-              -- fromMaybe "Unnamed" (getThreatModelName tm) `elem` names
               let tmName = fromMaybe "Unnamed" (getThreatModelName tm)
                in any (`isPrefixOf` tmName) names
 
@@ -700,7 +699,6 @@ positiveTestFast opts mGetTmResultsRef tms evs = do
           case threatModelFilter of
             [] -> True -- empty list: run all threat models
             names ->
-              -- fromMaybe "Unnamed" (getThreatModelName tm) `elem` names
               let tmName = fromMaybe "Unnamed" (getThreatModelName tm)
                in any (`isPrefixOf` tmName) names
 

--- a/src/testing-interface/lib/Convex/TestingInterface/Options.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface/Options.hs
@@ -5,8 +5,11 @@ module Convex.TestingInterface.Options (
   listThreatModelsIngredient,
   ListThreatModelsJson (..),
   listThreatModelsJsonIngredient,
+  testingInterfaceIngredients,
+  defaultMainTestingInterface,
 ) where
 
+import Convex.Tasty.Streaming (defaultMainStreamingWithIngredients)
 import Convex.ThreatModel.All (allThreatModelsNames)
 import Data.Aeson ((.=))
 import Data.Aeson qualified as Aeson
@@ -15,8 +18,10 @@ import Data.ByteString.Lazy.Char8 qualified as LBS
 import Data.Proxy (Proxy (..))
 import Data.Tagged (Tagged (..))
 import Data.Typeable (Typeable)
+import GHC.Stack (HasCallStack, withFrozenCallStack)
 import System.Exit (exitSuccess)
 import System.IO (BufferMode (..), hSetBuffering, stdout)
+import Test.Tasty (TestTree)
 import Test.Tasty.Ingredients (Ingredient (..))
 import Test.Tasty.Options (IsOption (..), OptionDescription (..), lookupOption, mkFlagCLParser, safeRead)
 
@@ -95,3 +100,16 @@ listThreatModelsJsonIngredient =
               hSetBuffering stdout LineBuffering
               LBS.putStrLn $ Aeson.encode $ Aeson.object [Key.fromString "threatModels" .= allThreatModelsNames]
               exitSuccess
+
+-- | Common testing-interface ingredients to combine with streaming defaults.
+testingInterfaceIngredients :: [Ingredient]
+testingInterfaceIngredients =
+  [ listThreatModelsIngredient
+  , listThreatModelsJsonIngredient
+  , threatModelNameFilterIngredient
+  ]
+
+-- | Default test-suite entrypoint for testing-interface packages.
+defaultMainTestingInterface :: (HasCallStack) => TestTree -> IO ()
+defaultMainTestingInterface =
+  withFrozenCallStack $ defaultMainStreamingWithIngredients testingInterfaceIngredients

--- a/src/testing-interface/lib/Convex/TestingInterface/Options.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface/Options.hs
@@ -1,0 +1,97 @@
+module Convex.TestingInterface.Options (
+  ThreatModelNameFilter (..),
+  threatModelNameFilterIngredient,
+  ListThreatModels (..),
+  listThreatModelsIngredient,
+  ListThreatModelsJson (..),
+  listThreatModelsJsonIngredient,
+) where
+
+import Convex.ThreatModel.All (allThreatModelsNames)
+import Data.Aeson ((.=))
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.ByteString.Lazy.Char8 qualified as LBS
+import Data.Proxy (Proxy (..))
+import Data.Tagged (Tagged (..))
+import Data.Typeable (Typeable)
+import System.Exit (exitSuccess)
+import System.IO (BufferMode (..), hSetBuffering, stdout)
+import Test.Tasty.Ingredients (Ingredient (..))
+import Test.Tasty.Options (IsOption (..), OptionDescription (..), lookupOption, mkFlagCLParser, safeRead)
+
+newtype ThreatModelNameFilter = ThreatModelNameFilter [String]
+  deriving (Eq, Ord, Typeable)
+
+instance Monoid ThreatModelNameFilter where
+  mempty = ThreatModelNameFilter []
+
+instance Semigroup ThreatModelNameFilter where
+  ThreatModelNameFilter a <> ThreatModelNameFilter b = ThreatModelNameFilter (a <> b)
+
+instance IsOption ThreatModelNameFilter where
+  defaultValue = ThreatModelNameFilter []
+  parseValue raw = Just (ThreatModelNameFilter (parseThreatModelNames raw))
+   where
+    parseThreatModelNames s =
+      case s of
+        "" -> []
+        _ -> map trim (splitOn ',' s)
+    splitOn _ [] = []
+    splitOn delim s = case break (== delim) s of
+      (a, []) -> [a]
+      (a, _ : rest) -> a : splitOn delim rest
+    trim = dropWhile (== ' ') . reverse . dropWhile (== ' ') . reverse
+  optionName = Tagged "threat-model-name"
+  optionHelp = Tagged "Run only threat models whose names start with these values (comma-separated for multiple; case-sensitive); expected vulnerabilities are unaffected"
+
+threatModelNameFilterIngredient :: Ingredient
+threatModelNameFilterIngredient =
+  TestManager
+    [Option (Proxy :: Proxy ThreatModelNameFilter)]
+    (\_ _ -> Nothing)
+
+newtype ListThreatModels = ListThreatModels Bool
+  deriving (Eq, Ord, Typeable)
+
+instance IsOption ListThreatModels where
+  defaultValue = ListThreatModels False
+  parseValue = Just . ListThreatModels . (== "True")
+  optionName = Tagged "list-threat-models"
+  optionHelp = Tagged "List all available threat models and exit (does not run tests)"
+  optionCLParser = mkFlagCLParser mempty (ListThreatModels True)
+
+listThreatModelsIngredient :: Ingredient
+listThreatModelsIngredient =
+  TestManager
+    [Option (Proxy :: Proxy ListThreatModels)]
+    $ \opts _ ->
+      let ListThreatModels shouldList = lookupOption opts
+       in if not shouldList
+            then Nothing
+            else Just $ do
+              mapM_ putStrLn allThreatModelsNames
+              exitSuccess
+
+newtype ListThreatModelsJson = ListThreatModelsJson Bool
+  deriving (Eq, Ord, Typeable)
+
+instance IsOption ListThreatModelsJson where
+  defaultValue = ListThreatModelsJson False
+  parseValue = fmap ListThreatModelsJson . safeRead
+  optionName = Tagged "list-threat-models-json"
+  optionHelp = Tagged "List all available threat models as JSON and exit (does not run tests)"
+  optionCLParser = mkFlagCLParser mempty (ListThreatModelsJson True)
+
+listThreatModelsJsonIngredient :: Ingredient
+listThreatModelsJsonIngredient =
+  TestManager
+    [Option (Proxy :: Proxy ListThreatModelsJson)]
+    $ \opts _ ->
+      let ListThreatModelsJson shouldList = lookupOption opts
+       in if not shouldList
+            then Nothing
+            else Just $ do
+              hSetBuffering stdout LineBuffering
+              LBS.putStrLn $ Aeson.encode $ Aeson.object [Key.fromString "threatModels" .= allThreatModelsNames]
+              exitSuccess

--- a/src/testing-interface/lib/Convex/TestingInterface/Options.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface/Options.hs
@@ -23,7 +23,7 @@ import System.Exit (exitSuccess)
 import System.IO (BufferMode (..), hSetBuffering, stdout)
 import Test.Tasty (TestTree)
 import Test.Tasty.Ingredients (Ingredient (..))
-import Test.Tasty.Options (IsOption (..), OptionDescription (..), lookupOption, mkFlagCLParser, safeRead)
+import Test.Tasty.Options (IsOption (..), OptionDescription (Option), lookupOption, mkFlagCLParser, safeRead)
 
 newtype ThreatModelNameFilter = ThreatModelNameFilter [String]
   deriving (Eq, Ord, Typeable)
@@ -41,8 +41,7 @@ instance IsOption ThreatModelNameFilter where
     parseThreatModelNames s =
       case s of
         "" -> []
-        _ -> map trim (splitOn ',' s)
-    splitOn _ [] = []
+        _ -> filter (not . null) $ map trim (splitOn ',' s)
     splitOn delim s = case break (== delim) s of
       (a, []) -> [a]
       (a, _ : rest) -> a : splitOn delim rest

--- a/src/testing-interface/lib/Convex/ThreatModel/All.hs
+++ b/src/testing-interface/lib/Convex/ThreatModel/All.hs
@@ -1,6 +1,6 @@
 module Convex.ThreatModel.All where
 
-import Convex.ThreatModel (ThreatModel)
+import Convex.ThreatModel (ThreatModel, getThreatModelName)
 import Convex.ThreatModel.DatumBloat (datumByteBloatAttack, datumListBloatAttack)
 import Convex.ThreatModel.DoubleSatisfaction (doubleSatisfaction)
 import Convex.ThreatModel.DuplicateListEntry (duplicateListEntryAttack)
@@ -18,6 +18,7 @@ import Convex.ThreatModel.SignatoryRemoval (signatoryRemoval)
 import Convex.ThreatModel.TimeBoundManipulation (timeBoundManipulation)
 import Convex.ThreatModel.UnprotectedScriptOutput (unprotectedScriptOutput)
 import Convex.ThreatModel.ValueUnderpayment (valueUnderpaymentAttack)
+import Data.Maybe (mapMaybe)
 
 {- | A list of all the threat models that don't take parameters.
 Almost all threat models in this library have versions without parameters, except @TokenForgery@.
@@ -45,23 +46,4 @@ allThreatModels =
   ]
 
 allThreatModelsNames :: [String]
-allThreatModelsNames =
-  [ "Datum List Bloat Attack"
-  , "Datum Byte Bloat Attack"
-  , "Double Satisfaction"
-  , "Duplicate List Entry Attack"
-  , "Input Duplication"
-  , "Invalid Datum Index Attack"
-  , "Large Data Attack"
-  , "Large Value Attack"
-  , "Missing Output Datum Attack"
-  , "Mutual Exclusion Attack"
-  , "Negative Integer Attack"
-  , "Output Datum Hash Missing Attack"
-  , "Redeemer Asset Substitution"
-  , "Self-Reference Injection"
-  , "Signatory Removal"
-  , "Time Bound Manipulation"
-  , "Unprotected Script Output"
-  , "Value Underpayment Attack"
-  ]
+allThreatModelsNames = mapMaybe getThreatModelName allThreatModels

--- a/src/testing-interface/lib/Convex/ThreatModel/All.hs
+++ b/src/testing-interface/lib/Convex/ThreatModel/All.hs
@@ -43,3 +43,25 @@ allThreatModels =
   , unprotectedScriptOutput
   , valueUnderpaymentAttack
   ]
+
+allThreatModelsNames :: [String]
+allThreatModelsNames =
+  [ "Datum List Bloat Attack"
+  , "Datum Byte Bloat Attack"
+  , "Double Satisfaction"
+  , "Duplicate List Entry Attack"
+  , "Input Duplication"
+  , "Invalid Datum Index Attack"
+  , "Large Data Attack"
+  , "Large Value Attack"
+  , "Missing Output Datum Attack"
+  , "Mutual Exclusion Attack"
+  , "Negative Integer Attack"
+  , "Output Datum Hash Missing Attack"
+  , "Redeemer Asset Substitution"
+  , "Self-Reference Injection"
+  , "Signatory Removal"
+  , "Time Bound Manipulation"
+  , "Unprotected Script Output"
+  , "Value Underpayment Attack"
+  ]

--- a/src/testing-interface/lib/Convex/ThreatModel/All.hs
+++ b/src/testing-interface/lib/Convex/ThreatModel/All.hs
@@ -16,6 +16,7 @@ import Convex.ThreatModel.RedeemerAssetSubstitution (redeemerAssetSubstitution)
 import Convex.ThreatModel.SelfReferenceInjection (selfReferenceInjection)
 import Convex.ThreatModel.SignatoryRemoval (signatoryRemoval)
 import Convex.ThreatModel.TimeBoundManipulation (timeBoundManipulation)
+import Convex.ThreatModel.TokenForgery (simpleAlwaysSucceedsMintingPolicyV2, simpleTestAssetName, tokenForgeryAttack)
 import Convex.ThreatModel.UnprotectedScriptOutput (unprotectedScriptOutput)
 import Convex.ThreatModel.ValueUnderpayment (valueUnderpaymentAttack)
 import Data.Maybe (mapMaybe)
@@ -41,6 +42,7 @@ allThreatModels =
   , selfReferenceInjection
   , signatoryRemoval
   , timeBoundManipulation
+  , tokenForgeryAttack simpleAlwaysSucceedsMintingPolicyV2 simpleTestAssetName
   , unprotectedScriptOutput
   , valueUnderpaymentAttack
   ]

--- a/src/testing-interface/test/AikenPurchaseOfferSpec.hs
+++ b/src/testing-interface/test/AikenPurchaseOfferSpec.hs
@@ -89,7 +89,6 @@ import Convex.Tasty.QuickCheck (
 import Convex.Tasty.QuickCheck qualified as QC
 import Convex.ThreatModel.LargeData (largeDataAttack)
 import Convex.ThreatModel.TimeBoundManipulation (timeBoundManipulation)
-import Convex.ThreatModel.TokenForgery (simpleAlwaysSucceedsMintingPolicyV2, simpleTestAssetName, tokenForgeryAttack)
 import Data.Aeson (ToJSON (..))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.QuickCheck.Monadic (monadicIO, monitor, run)
@@ -706,56 +705,7 @@ instance TestingInterface PurchaseOfferModel where
       void $ balanceAndSubmit mempty Wallet.w1 txBody TrailingChange []
       pure $
         model
-          { pomInitialized =
-              Trueoken Forgery Attack
-                / 'to rerun this test only
-                  . Unprotected Script Output
-                : OK
-                  SKIPPED
-                : Precondition
-                  never
-                  met
-                  (0 / 100 transactions applicable)
-                  Value
-                  Underpayment
-                  Attack
-                  (50.0 % reduction)
-                : OK
-                  Tested
-                  100
-                  / 100
-                    transactions
-                    (0 skipped, 0 errors)
-                    Expected
-                    vulnerabilities
-                    Redeemer
-                    Asset
-                    Substitution
-                : OK
-                  Vulnerability
-                  detected
-                  (100 / 100 transactions, 0 skipped, 0 errors)
-                  Time
-                  Bound
-                  Manipulation
-                  (slot 0)
-                : OK
-                  Vulnerability
-                  detected
-                  (100 / 100 transactions, 0 skipped, 0 errors)
-                  Large
-                  Data
-                  Attack
-                  (max 1000 fields)
-                : OK
-                  SKIPPED
-                : Precondition
-                  never
-                  met
-                  (0 / 100 transactions applicable)
-                  redeemer
-                  - controlled asset vulnerability confirmed
-                : OK (0.56 s)
+          { pomInitialized = True
           , pomTxIn = Just (C.TxIn dummyTxId (C.TxIx 0))
           , pomValue = amount
           , pomDesiredPolicyId = Just testPolicyIdBytes
@@ -793,7 +743,7 @@ instance TestingInterface PurchaseOfferModel where
   monitoring _state _action prop = prop
 
 instance ThreatModelsFor PurchaseOfferModel where
-  expectedVulnerabilities = [redeemerAssetSubstitution, timeBoundManipulation, largeDataAttack, tokenForgeryAttack simpleAlwaysSucceedsMintingPolicyV2 simpleTestAssetName]
+  expectedVulnerabilities = [redeemerAssetSubstitution, timeBoundManipulation, largeDataAttack]
 
 -- ----------------------------------------------------------------------------
 -- Test tree

--- a/src/testing-interface/test/AikenPurchaseOfferSpec.hs
+++ b/src/testing-interface/test/AikenPurchaseOfferSpec.hs
@@ -87,8 +87,8 @@ import Convex.Tasty.QuickCheck (
   testProperty,
  )
 import Convex.Tasty.QuickCheck qualified as QC
-import Convex.ThreatModel.LargeData (largeDataAttack)
 import Convex.ThreatModel.TimeBoundManipulation (timeBoundManipulation)
+import Convex.ThreatModel.TokenForgery (simpleAlwaysSucceedsMintingPolicyV2, simpleTestAssetName, tokenForgeryAttack)
 import Data.Aeson (ToJSON (..))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.QuickCheck.Monadic (monadicIO, monitor, run)
@@ -743,7 +743,7 @@ instance TestingInterface PurchaseOfferModel where
   monitoring _state _action prop = prop
 
 instance ThreatModelsFor PurchaseOfferModel where
-  expectedVulnerabilities = [redeemerAssetSubstitution, timeBoundManipulation, largeDataAttack]
+  expectedVulnerabilities = [redeemerAssetSubstitution, timeBoundManipulation, tokenForgeryAttack simpleAlwaysSucceedsMintingPolicyV2 simpleTestAssetName]
 
 -- ----------------------------------------------------------------------------
 -- Test tree

--- a/src/testing-interface/test/AikenPurchaseOfferSpec.hs
+++ b/src/testing-interface/test/AikenPurchaseOfferSpec.hs
@@ -89,6 +89,7 @@ import Convex.Tasty.QuickCheck (
 import Convex.Tasty.QuickCheck qualified as QC
 import Convex.ThreatModel.LargeData (largeDataAttack)
 import Convex.ThreatModel.TimeBoundManipulation (timeBoundManipulation)
+import Convex.ThreatModel.TokenForgery (simpleAlwaysSucceedsMintingPolicyV2, simpleTestAssetName, tokenForgeryAttack)
 import Data.Aeson (ToJSON (..))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.QuickCheck.Monadic (monadicIO, monitor, run)
@@ -705,7 +706,56 @@ instance TestingInterface PurchaseOfferModel where
       void $ balanceAndSubmit mempty Wallet.w1 txBody TrailingChange []
       pure $
         model
-          { pomInitialized = True
+          { pomInitialized =
+              Trueoken Forgery Attack
+                / 'to rerun this test only
+                  . Unprotected Script Output
+                : OK
+                  SKIPPED
+                : Precondition
+                  never
+                  met
+                  (0 / 100 transactions applicable)
+                  Value
+                  Underpayment
+                  Attack
+                  (50.0 % reduction)
+                : OK
+                  Tested
+                  100
+                  / 100
+                    transactions
+                    (0 skipped, 0 errors)
+                    Expected
+                    vulnerabilities
+                    Redeemer
+                    Asset
+                    Substitution
+                : OK
+                  Vulnerability
+                  detected
+                  (100 / 100 transactions, 0 skipped, 0 errors)
+                  Time
+                  Bound
+                  Manipulation
+                  (slot 0)
+                : OK
+                  Vulnerability
+                  detected
+                  (100 / 100 transactions, 0 skipped, 0 errors)
+                  Large
+                  Data
+                  Attack
+                  (max 1000 fields)
+                : OK
+                  SKIPPED
+                : Precondition
+                  never
+                  met
+                  (0 / 100 transactions applicable)
+                  redeemer
+                  - controlled asset vulnerability confirmed
+                : OK (0.56 s)
           , pomTxIn = Just (C.TxIn dummyTxId (C.TxIx 0))
           , pomValue = amount
           , pomDesiredPolicyId = Just testPolicyIdBytes
@@ -743,7 +793,7 @@ instance TestingInterface PurchaseOfferModel where
   monitoring _state _action prop = prop
 
 instance ThreatModelsFor PurchaseOfferModel where
-  expectedVulnerabilities = [redeemerAssetSubstitution, timeBoundManipulation, largeDataAttack]
+  expectedVulnerabilities = [redeemerAssetSubstitution, timeBoundManipulation, largeDataAttack, tokenForgeryAttack simpleAlwaysSucceedsMintingPolicyV2 simpleTestAssetName]
 
 -- ----------------------------------------------------------------------------
 -- Test tree

--- a/src/testing-interface/test/Spec.hs
+++ b/src/testing-interface/test/Spec.hs
@@ -3,18 +3,24 @@
 import Cardano.Api qualified as C
 import Convex.MockChain.Utils (mockchainFails)
 import Convex.Tasty.HUnit (testCase)
-import Convex.Tasty.Streaming (defaultMainStreaming)
+import Convex.Tasty.Streaming (streamingIngredients)
 import Convex.TestingInterface (
   CoverageConfig (..),
   Options,
-  RunOptions (mcOptions),
+  RunOptions (mcOptions, threatModelFilter),
   mockchainSucceedsWithOptions,
   modifyTransactionLimits,
   withCoverage,
   writeCoverageReport,
  )
+import Convex.TestingInterface.Options (
+  ThreatModelNameFilter (..),
+  listThreatModelsIngredient,
+  listThreatModelsJsonIngredient,
+  threatModelNameFilterIngredient,
+ )
 import Convex.Utils (failOnError)
-import Test.Tasty (TestTree, testGroup)
+import Test.Tasty (TestTree, askOption, defaultMainWithIngredients, testGroup)
 
 import AikenBankSpec (aikenBankTests)
 import AikenHelloWorldSpec (aikenHelloWorldTests)
@@ -45,7 +51,11 @@ main = withCoverage config $ \opts0 runOpts0 ->
     opts = modifyTransactionLimits opts0 50_000
     runOpts = runOpts0{mcOptions = opts}
    in
-    defaultMainStreaming (tests opts runOpts)
+    defaultMainWithIngredients
+      (listThreatModelsIngredient : listThreatModelsJsonIngredient : threatModelNameFilterIngredient : streamingIngredients)
+      ( askOption $ \(ThreatModelNameFilter tmNameFilter) ->
+          tests opts runOpts{threatModelFilter = tmNameFilter}
+      )
  where
   config =
     CoverageConfig

--- a/src/testing-interface/test/Spec.hs
+++ b/src/testing-interface/test/Spec.hs
@@ -3,11 +3,11 @@
 import Cardano.Api qualified as C
 import Convex.MockChain.Utils (mockchainFails)
 import Convex.Tasty.HUnit (testCase)
-import Convex.Tasty.Streaming (streamingIngredients)
 import Convex.TestingInterface (
   CoverageConfig (..),
   Options,
   RunOptions (mcOptions, threatModelFilter),
+  defaultMainTestingInterface,
   mockchainSucceedsWithOptions,
   modifyTransactionLimits,
   withCoverage,
@@ -15,12 +15,9 @@ import Convex.TestingInterface (
  )
 import Convex.TestingInterface.Options (
   ThreatModelNameFilter (..),
-  listThreatModelsIngredient,
-  listThreatModelsJsonIngredient,
-  threatModelNameFilterIngredient,
  )
 import Convex.Utils (failOnError)
-import Test.Tasty (TestTree, askOption, defaultMainWithIngredients, testGroup)
+import Test.Tasty (TestTree, askOption, testGroup)
 
 import AikenBankSpec (aikenBankTests)
 import AikenHelloWorldSpec (aikenHelloWorldTests)
@@ -51,8 +48,7 @@ main = withCoverage config $ \opts0 runOpts0 ->
     opts = modifyTransactionLimits opts0 50_000
     runOpts = runOpts0{mcOptions = opts}
    in
-    defaultMainWithIngredients
-      (listThreatModelsIngredient : listThreatModelsJsonIngredient : threatModelNameFilterIngredient : streamingIngredients)
+    defaultMainTestingInterface
       ( askOption $ \(ThreatModelNameFilter tmNameFilter) ->
           tests opts runOpts{threatModelFilter = tmNameFilter}
       )


### PR DESCRIPTION
Issue #46 

This pull request adds support for filtering and listing available threat models from the CLI in the testing interface. Users can now list all threat models, filter which ones to run by name (with prefix matching), and obtain the list in JSON format. These options are exposed via new CLI flags and are integrated into the test runner. The documentation is updated accordingly.

**New CLI options and threat model filtering:**

* Introduced the `--threat-model-name` option, allowing users to filter which threat models run by prefix-based, case-sensitive name matching. This affects only threat models, not expected vulnerabilities. [[1]](diffhunk://#diff-f350314850eafc500ca5410cec7ed22d6350ea9899f08ac3f23f029179e1477dR298-R302) [[2]](diffhunk://#diff-f350314850eafc500ca5410cec7ed22d6350ea9899f08ac3f23f029179e1477dL598-R622) [[3]](diffhunk://#diff-f350314850eafc500ca5410cec7ed22d6350ea9899f08ac3f23f029179e1477dL674-R716) [[4]](diffhunk://#diff-8800cbafd2772eaba5befe7a1977d5f104b00d1e2a71a92cf41e2a0a2678f556R1-R97) [[5]](diffhunk://#diff-ff64ae96d2f23cd38a153e3fd8c68c3f381544c2a35e9f9b6f49a57b9ab845d9L6-R23) [[6]](diffhunk://#diff-ff64ae96d2f23cd38a153e3fd8c68c3f381544c2a35e9f9b6f49a57b9ab845d9L48-R58)
* Added `--list-threat-models` and `--list-threat-models-json` CLI options to print all available threat model names (plain text or JSON) and exit, without running tests. [[1]](diffhunk://#diff-8800cbafd2772eaba5befe7a1977d5f104b00d1e2a71a92cf41e2a0a2678f556R1-R97) [[2]](diffhunk://#diff-ff64ae96d2f23cd38a153e3fd8c68c3f381544c2a35e9f9b6f49a57b9ab845d9L6-R23) [[3]](diffhunk://#diff-ff64ae96d2f23cd38a153e3fd8c68c3f381544c2a35e9f9b6f49a57b9ab845d9L48-R58) [[4]](diffhunk://#diff-77d74ac8075dee376626d3e3b2e8356ee290a4ce887bb8869237cdbb41116ca8R46-R67)

**Codebase and documentation updates:**

* Updated the `RunOptions` data structure and default options to include the new threat model filter. [[1]](diffhunk://#diff-f350314850eafc500ca5410cec7ed22d6350ea9899f08ac3f23f029179e1477dR298-R302) [[2]](diffhunk://#diff-f350314850eafc500ca5410cec7ed22d6350ea9899f08ac3f23f029179e1477dR312)
* Refactored the CLI test runner and test suite setup to support the new options and ingredients. [[1]](diffhunk://#diff-ff64ae96d2f23cd38a153e3fd8c68c3f381544c2a35e9f9b6f49a57b9ab845d9L6-R23) [[2]](diffhunk://#diff-ff64ae96d2f23cd38a153e3fd8c68c3f381544c2a35e9f9b6f49a57b9ab845d9L48-R58)
* Added documentation in `README.md` explaining how to use the new threat model filtering and listing features from the CLI.

**Dependency and module changes:**

* Added the `tagged` package dependency and exposed the new `Convex.TestingInterface.Options` module. [[1]](diffhunk://#diff-abfb6e8023ccbcf0cbbdd28f2bbea9ee7ddf86a2990f02930e40c40101893edfR45) [[2]](diffhunk://#diff-abfb6e8023ccbcf0cbbdd28f2bbea9ee7ddf86a2990f02930e40c40101893edfR94)

**Threat model metadata:**

* Added a static list of all threat model names in `Convex.ThreatModel.All` for use by the listing features.