### PR TITLE
Adding JSON output for monitoring events in the testing interface

### DIFF
--- a/src/schema-gen/lib/Convex/SchemaGen.hs
+++ b/src/schema-gen/lib/Convex/SchemaGen.hs
@@ -21,7 +21,17 @@ import Data.Text qualified as Text
 
 -- Types from convex-tasty-streaming
 import Convex.Tasty.Streaming.TMSummary (ThreatModelSummary (..))
-import Convex.Tasty.Streaming.Types (Event (..), FailureInfo (..), TestInfo (..), TestOutcome (..))
+import Convex.Tasty.Streaming.Types (
+  Event (..),
+  FailureInfo (..),
+  MonitoringClassStat (..),
+  MonitoringLabelStat (..),
+  MonitoringStats (..),
+  MonitoringTableEntry (..),
+  MonitoringTableStat (..),
+  TestInfo (..),
+  TestOutcome (..),
+ )
 
 -- Types from convex-testing-interface
 import Convex.TestingInterface.Trace (
@@ -144,11 +154,86 @@ instance ToSchema ThreatModelSummary where
               ]
           & required .~ ["name", "tested", "total", "passed", "failed", "skipped", "errors"]
 
+instance ToSchema MonitoringLabelStat where
+  declareNamedSchema _ =
+    pure $
+      NamedSchema (Just "MonitoringLabelStat") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ InsOrdHashMap.fromList
+              [ ("labels", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject (Inline $ mempty & type_ ?~ OpenApiString))
+              , ("count", Inline $ mempty & type_ ?~ OpenApiInteger)
+              , ("percent", Inline $ mempty & type_ ?~ OpenApiNumber & format ?~ "double")
+              ]
+          & required .~ ["labels", "count", "percent"]
+
+instance ToSchema MonitoringClassStat where
+  declareNamedSchema _ =
+    pure $
+      NamedSchema (Just "MonitoringClassStat") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ InsOrdHashMap.fromList
+              [ ("name", Inline $ mempty & type_ ?~ OpenApiString)
+              , ("count", Inline $ mempty & type_ ?~ OpenApiInteger)
+              , ("percent", Inline $ mempty & type_ ?~ OpenApiNumber & format ?~ "double")
+              ]
+          & required .~ ["name", "count", "percent"]
+
+instance ToSchema MonitoringTableEntry where
+  declareNamedSchema _ =
+    pure $
+      NamedSchema (Just "MonitoringTableEntry") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ InsOrdHashMap.fromList
+              [ ("value", Inline $ mempty & type_ ?~ OpenApiString)
+              , ("count", Inline $ mempty & type_ ?~ OpenApiInteger)
+              ]
+          & required .~ ["value", "count"]
+
+instance ToSchema MonitoringTableStat where
+  declareNamedSchema _ = do
+    entryRef <- declareSchemaRef (Proxy @MonitoringTableEntry)
+    pure $
+      NamedSchema (Just "MonitoringTableStat") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ InsOrdHashMap.fromList
+              [ ("name", Inline $ mempty & type_ ?~ OpenApiString)
+              , ("entries", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject entryRef)
+              ]
+          & required .~ ["name", "entries"]
+
+instance ToSchema MonitoringStats where
+  declareNamedSchema _ = do
+    labelRef <- declareSchemaRef (Proxy @MonitoringLabelStat)
+    classRef <- declareSchemaRef (Proxy @MonitoringClassStat)
+    tableRef <- declareSchemaRef (Proxy @MonitoringTableStat)
+    pure $
+      NamedSchema (Just "MonitoringStats") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ InsOrdHashMap.fromList
+              [ ("numTests", Inline $ mempty & type_ ?~ OpenApiInteger)
+              , ("numDiscarded", Inline $ mempty & type_ ?~ OpenApiInteger)
+              , ("labels", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject labelRef)
+              , ("classes", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject classRef)
+              , ("tables", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject tableRef)
+              ]
+          & required .~ ["numTests", "numDiscarded", "labels", "classes", "tables"]
+
 instance ToSchema Event where
   declareNamedSchema _ = do
     testInfoRef <- declareSchemaRef (Proxy @TestInfo)
     failureInfoRef <- declareSchemaRef (Proxy @FailureInfo)
     threatModelSummaryRef <- declareSchemaRef (Proxy @ThreatModelSummary)
+    monitoringStatsRef <- declareSchemaRef (Proxy @MonitoringStats)
     iterationTraceRef <- declareSchemaRef (Proxy @IterationTrace)
 
     let suiteStarted =
@@ -198,6 +283,7 @@ instance ToSchema Event where
                 , ("success", Inline $ mempty & type_ ?~ OpenApiBoolean)
                 , ("failure", failureInfoRef) -- optional, absent when success=true
                 , ("threat_model", threatModelSummaryRef) -- optional, absent when not applicable
+                , ("monitoring_stats", monitoringStatsRef) -- optional, absent when quickcheck wrapper is not used
                 ]
             & required .~ ["event", "id", "duration", "description", "success"]
 

--- a/src/tasty-streaming/convex-tasty-streaming.cabal
+++ b/src/tasty-streaming/convex-tasty-streaming.cabal
@@ -41,6 +41,7 @@ library
     Convex.Tasty.HUnit
     Convex.Tasty.QuickCheck
     Convex.Tasty.Streaming
+    Convex.Tasty.Streaming.QCStats
     Convex.Tasty.Streaming.SrcLoc
     Convex.Tasty.Streaming.TMSummary
     Convex.Tasty.Streaming.TreeMap
@@ -55,6 +56,7 @@ library
     , containers
     , directory
     , filepath
+    , QuickCheck
     , stm
     , tagged
     , tasty             >=1.4

--- a/src/tasty-streaming/lib/Convex/Tasty/QuickCheck.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/QuickCheck.hs
@@ -21,7 +21,12 @@ module Convex.Tasty.QuickCheck (
   module Test.Tasty.QuickCheck,
 ) where
 
-import Convex.Tasty.Streaming.QCStats (QCStatsRecorder (..), recordQCStatsFromState)
+import Convex.Tasty.Streaming.QCStats (
+  QCStatsPathIndex (..),
+  QCStatsRecorder (..),
+  recordQCStatsFromState,
+  resolveQCStatsPath,
+ )
 import Convex.Tasty.Streaming.SrcLoc (SrcLocOpt (..), withSrcLoc)
 import GHC.Stack (HasCallStack, withFrozenCallStack)
 import Test.QuickCheck.Property qualified as QCP
@@ -42,12 +47,13 @@ testProperty name prop =
                 Nothing -> QC.testProperty name baseProp
                 Just _ ->
                   askOption $ \(recorder :: QCStatsRecorder) ->
-                    let postTest =
-                          QCP.callback $ QCP.PostTest QCP.NotCounterexample $ \st _ ->
-                            recordQCStatsFromState recorder mLoc name st
-                        postFinalFailure =
-                          QCP.callback $ QCP.PostFinalFailure QCP.NotCounterexample $ \st _ ->
-                            recordQCStatsFromState recorder mLoc name st
-                        instrumented = postFinalFailure (postTest baseProp)
-                     in QC.testProperty name instrumented
+                    askOption $ \(pathIndex :: QCStatsPathIndex) ->
+                      let postTest =
+                            QCP.callback $ QCP.PostTest QCP.NotCounterexample $ \st _ ->
+                              recordQCStatsFromState recorder mLoc (resolveQCStatsPath pathIndex mLoc name) name st
+                          postFinalFailure =
+                            QCP.callback $ QCP.PostFinalFailure QCP.NotCounterexample $ \st _ ->
+                              recordQCStatsFromState recorder mLoc (resolveQCStatsPath pathIndex mLoc name) name st
+                          instrumented = postFinalFailure (postTest baseProp)
+                       in QC.testProperty name instrumented
     )

--- a/src/tasty-streaming/lib/Convex/Tasty/QuickCheck.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/QuickCheck.hs
@@ -22,10 +22,8 @@ module Convex.Tasty.QuickCheck (
 ) where
 
 import Convex.Tasty.Streaming.QCStats (
-  QCStatsPathIndex (..),
   QCStatsRecorder (..),
   recordQCStatsFromState,
-  resolveQCStatsPath,
  )
 import Convex.Tasty.Streaming.SrcLoc (SrcLocOpt (..), withSrcLoc)
 import GHC.Stack (HasCallStack, withFrozenCallStack)
@@ -47,13 +45,12 @@ testProperty name prop =
                 Nothing -> QC.testProperty name baseProp
                 Just _ ->
                   askOption $ \(recorder :: QCStatsRecorder) ->
-                    askOption $ \(pathIndex :: QCStatsPathIndex) ->
-                      let postTest =
-                            QCP.callback $ QCP.PostTest QCP.NotCounterexample $ \st _ ->
-                              recordQCStatsFromState recorder mLoc (resolveQCStatsPath pathIndex mLoc name) name st
-                          postFinalFailure =
-                            QCP.callback $ QCP.PostFinalFailure QCP.NotCounterexample $ \st _ ->
-                              recordQCStatsFromState recorder mLoc (resolveQCStatsPath pathIndex mLoc name) name st
-                          instrumented = postFinalFailure (postTest baseProp)
-                       in QC.testProperty name instrumented
+                    let postTest =
+                          QCP.callback $ QCP.PostTest QCP.NotCounterexample $ \st _ ->
+                            recordQCStatsFromState recorder mLoc name st
+                        postFinalFailure =
+                          QCP.callback $ QCP.PostFinalFailure QCP.NotCounterexample $ \st _ ->
+                            recordQCStatsFromState recorder mLoc name st
+                        instrumented = postFinalFailure (postTest baseProp)
+                     in QC.testProperty name instrumented
     )

--- a/src/tasty-streaming/lib/Convex/Tasty/QuickCheck.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/QuickCheck.hs
@@ -34,15 +34,20 @@ range that the streaming ingredient will emit alongside the test.
 -}
 testProperty :: (HasCallStack, Testable a) => TestName -> a -> TestTree
 testProperty name prop =
-  withFrozenCallStack . withSrcLoc $ do
-    askOption $ \(SrcLocOpt mLoc) ->
-      askOption $ \(recorder :: QCStatsRecorder) ->
+  withFrozenCallStack
+    ( withSrcLoc $ do
         let baseProp = property prop
-            postTest =
-              QCP.callback $ QCP.PostTest QCP.NotCounterexample $ \st _ ->
-                recordQCStatsFromState recorder mLoc st
-            postFinalFailure =
-              QCP.callback $ QCP.PostFinalFailure QCP.NotCounterexample $ \st _ ->
-                recordQCStatsFromState recorder mLoc st
-            instrumented = postFinalFailure (postTest baseProp)
-         in QC.testProperty name instrumented
+        askOption $ \(SrcLocOpt mLoc) ->
+          case mLoc of
+            Nothing -> QC.testProperty name baseProp
+            Just _ ->
+              askOption $ \(recorder :: QCStatsRecorder) ->
+                let postTest =
+                      QCP.callback $ QCP.PostTest QCP.NotCounterexample $ \st _ ->
+                        recordQCStatsFromState recorder mLoc name st
+                    postFinalFailure =
+                      QCP.callback $ QCP.PostFinalFailure QCP.NotCounterexample $ \st _ ->
+                        recordQCStatsFromState recorder mLoc name st
+                    instrumented = postFinalFailure (postTest baseProp)
+                 in QC.testProperty name instrumented
+    )

--- a/src/tasty-streaming/lib/Convex/Tasty/QuickCheck.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/QuickCheck.hs
@@ -35,19 +35,19 @@ range that the streaming ingredient will emit alongside the test.
 testProperty :: (HasCallStack, Testable a) => TestName -> a -> TestTree
 testProperty name prop =
   withFrozenCallStack
-    ( withSrcLoc $ do
+    ( withSrcLoc $
         let baseProp = property prop
-        askOption $ \(SrcLocOpt mLoc) ->
-          case mLoc of
-            Nothing -> QC.testProperty name baseProp
-            Just _ ->
-              askOption $ \(recorder :: QCStatsRecorder) ->
-                let postTest =
-                      QCP.callback $ QCP.PostTest QCP.NotCounterexample $ \st _ ->
-                        recordQCStatsFromState recorder mLoc name st
-                    postFinalFailure =
-                      QCP.callback $ QCP.PostFinalFailure QCP.NotCounterexample $ \st _ ->
-                        recordQCStatsFromState recorder mLoc name st
-                    instrumented = postFinalFailure (postTest baseProp)
-                 in QC.testProperty name instrumented
+         in askOption $ \(SrcLocOpt mLoc) ->
+              case mLoc of
+                Nothing -> QC.testProperty name baseProp
+                Just _ ->
+                  askOption $ \(recorder :: QCStatsRecorder) ->
+                    let postTest =
+                          QCP.callback $ QCP.PostTest QCP.NotCounterexample $ \st _ ->
+                            recordQCStatsFromState recorder mLoc name st
+                        postFinalFailure =
+                          QCP.callback $ QCP.PostFinalFailure QCP.NotCounterexample $ \st _ ->
+                            recordQCStatsFromState recorder mLoc name st
+                        instrumented = postFinalFailure (postTest baseProp)
+                     in QC.testProperty name instrumented
     )

--- a/src/tasty-streaming/lib/Convex/Tasty/QuickCheck.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/QuickCheck.hs
@@ -21,9 +21,12 @@ module Convex.Tasty.QuickCheck (
   module Test.Tasty.QuickCheck,
 ) where
 
-import Convex.Tasty.Streaming.SrcLoc (withSrcLoc)
+import Convex.Tasty.Streaming.QCStats (QCStatsRecorder (..), recordQCStatsFromState)
+import Convex.Tasty.Streaming.SrcLoc (SrcLocOpt (..), withSrcLoc)
 import GHC.Stack (HasCallStack, withFrozenCallStack)
-import Test.Tasty (TestName, TestTree)
+import Test.QuickCheck (property)
+import Test.QuickCheck.Property qualified as QCP
+import Test.Tasty (TestName, TestTree, askOption)
 import Test.Tasty.QuickCheck hiding (testProperty)
 import Test.Tasty.QuickCheck qualified as QC
 
@@ -32,4 +35,15 @@ range that the streaming ingredient will emit alongside the test.
 -}
 testProperty :: (HasCallStack, Testable a) => TestName -> a -> TestTree
 testProperty name prop =
-  withFrozenCallStack (withSrcLoc (QC.testProperty name prop))
+  withFrozenCallStack . withSrcLoc $ do
+    askOption $ \(SrcLocOpt mLoc) ->
+      askOption $ \(recorder :: QCStatsRecorder) ->
+        let baseProp = property prop
+            postTest =
+              QCP.callback $ QCP.PostTest QCP.NotCounterexample $ \st _ ->
+                recordQCStatsFromState recorder mLoc st
+            postFinalFailure =
+              QCP.callback $ QCP.PostFinalFailure QCP.NotCounterexample $ \st _ ->
+                recordQCStatsFromState recorder mLoc st
+            instrumented = postFinalFailure (postTest baseProp)
+         in QC.testProperty name instrumented

--- a/src/tasty-streaming/lib/Convex/Tasty/QuickCheck.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/QuickCheck.hs
@@ -24,7 +24,6 @@ module Convex.Tasty.QuickCheck (
 import Convex.Tasty.Streaming.QCStats (QCStatsRecorder (..), recordQCStatsFromState)
 import Convex.Tasty.Streaming.SrcLoc (SrcLocOpt (..), withSrcLoc)
 import GHC.Stack (HasCallStack, withFrozenCallStack)
-import Test.QuickCheck (property)
 import Test.QuickCheck.Property qualified as QCP
 import Test.Tasty (TestName, TestTree, askOption)
 import Test.Tasty.QuickCheck hiding (testProperty)

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
@@ -10,11 +10,9 @@ import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Concurrent.STM
 import Control.Monad (when)
 import Convex.Tasty.Streaming.QCStats (
-  QCStatsPathIndex,
   QCStatsRecorder,
   QCStatsStoreOption (..),
   lookupQCStatsByTestInfo,
-  mkQCStatsPathIndex,
   newQCStatsStore,
   storeQCStatsRecorder,
  )
@@ -131,7 +129,6 @@ streamingJsonReporter = TestReporter
   , Option (Proxy :: Proxy NoTrace)
   , Option (Proxy :: Proxy QCStatsStoreOption)
   , Option (Proxy :: Proxy QCStatsRecorder)
-  , Option (Proxy :: Proxy QCStatsPathIndex)
   , Option (Proxy :: Proxy TMStoreOption)
   , Option (Proxy :: Proxy TMRecorder)
   , Option (Proxy :: Proxy TraceRecorder)
@@ -423,7 +420,4 @@ defaultMainStreaming tree = do
                     localOption (StreamingEnabledRef (Just enabledRef)) $
                       localOption (OutputLockRef (Just outputLock)) $
                         localOption traceRec tree
-  initialTestMap <- buildTestMap mempty treeWithOptions
-  let qcPathIndex = mkQCStatsPathIndex (IntMap.elems initialTestMap)
-      tree' = localOption qcPathIndex treeWithOptions
-  defaultMainWithIngredients streamingIngredients tree'
+  defaultMainWithIngredients streamingIngredients treeWithOptions

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
@@ -10,9 +10,11 @@ import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Concurrent.STM
 import Control.Monad (when)
 import Convex.Tasty.Streaming.QCStats (
+  QCStatsPathIndex,
   QCStatsRecorder,
   QCStatsStoreOption (..),
   lookupQCStatsByTestInfo,
+  mkQCStatsPathIndex,
   newQCStatsStore,
   storeQCStatsRecorder,
  )
@@ -129,6 +131,7 @@ streamingJsonReporter = TestReporter
   , Option (Proxy :: Proxy NoTrace)
   , Option (Proxy :: Proxy QCStatsStoreOption)
   , Option (Proxy :: Proxy QCStatsRecorder)
+  , Option (Proxy :: Proxy QCStatsPathIndex)
   , Option (Proxy :: Proxy TMStoreOption)
   , Option (Proxy :: Proxy TMRecorder)
   , Option (Proxy :: Proxy TraceRecorder)
@@ -410,7 +413,7 @@ defaultMainStreaming tree = do
                       , ettTrace = iterationJson
                       }
           }
-  let tree' =
+  let treeWithOptions =
         localOption pkgRootOpt $
           localOption (QCStatsStoreOption (Just qcStatsStore)) $
             localOption (storeQCStatsRecorder qcStatsStore) $
@@ -420,4 +423,7 @@ defaultMainStreaming tree = do
                     localOption (StreamingEnabledRef (Just enabledRef)) $
                       localOption (OutputLockRef (Just outputLock)) $
                         localOption traceRec tree
+  initialTestMap <- buildTestMap mempty treeWithOptions
+  let qcPathIndex = mkQCStatsPathIndex (IntMap.elems initialTestMap)
+      tree' = localOption qcPathIndex treeWithOptions
   defaultMainWithIngredients streamingIngredients tree'

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
@@ -9,6 +9,13 @@ import Control.Concurrent.Async (forConcurrently_)
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Concurrent.STM
 import Control.Monad (when)
+import Convex.Tasty.Streaming.QCStats (
+  QCStatsRecorder,
+  QCStatsStoreOption (..),
+  lookupQCStatsBySrcLoc,
+  newQCStatsStore,
+  storeQCStatsRecorder,
+ )
 import Convex.Tasty.Streaming.SrcLoc (PackageRootOpt (..), callerPackageRoot)
 import Convex.Tasty.Streaming.TMSummary (
   TMRecorder,
@@ -120,6 +127,8 @@ streamingJsonReporter :: Ingredient
 streamingJsonReporter = TestReporter
   [ Option (Proxy :: Proxy StreamingJson)
   , Option (Proxy :: Proxy NoTrace)
+  , Option (Proxy :: Proxy QCStatsStoreOption)
+  , Option (Proxy :: Proxy QCStatsRecorder)
   , Option (Proxy :: Proxy TMStoreOption)
   , Option (Proxy :: Proxy TMRecorder)
   , Option (Proxy :: Proxy TraceRecorder)
@@ -134,6 +143,7 @@ streamingJsonReporter = TestReporter
       then Nothing
       else Just $ \statusMap -> do
         let TMStoreOption mStore = lookupOption opts
+            QCStatsStoreOption mQCStatsStore = lookupOption opts
             TestMapRef mTestMapRef = lookupOption opts
             StreamingEnabledRef mEnabledRef = lookupOption opts
 
@@ -227,6 +237,9 @@ streamingJsonReporter = TestReporter
           mSummary <- case mStore of
             Just store -> lookupThreatModelSummary store key
             Nothing -> pure Nothing
+          mMonitoring <- case (mQCStatsStore, testInfo >>= tiSrcLoc) of
+            (Just store, Just loc) -> lookupQCStatsBySrcLoc store loc
+            _ -> pure Nothing
 
           -- Emit test_done
           let outcome = case resultOutcome result of
@@ -244,6 +257,7 @@ streamingJsonReporter = TestReporter
               , edDuration = resultTime result
               , edDescription = Text.pack (resultDescription result)
               , edThreatModel = mSummary
+              , edMonitoringStats = mMonitoring
               }
 
         -- Emit suite_done summary
@@ -366,6 +380,7 @@ defaultMainStreaming tree = do
   mPkgRoot <- withFrozenCallStack callerPackageRoot
   let pkgRootOpt = PackageRootOpt (fmap Text.pack mPkgRoot)
   store <- newTMStore
+  qcStatsStore <- newQCStatsStore
   testMapRef <- newIORef IntMap.empty
   enabledRef <- newIORef False -- set to True by the reporter when --streaming-json is active
   -- Create a single shared output lock used by both the streaming reporter
@@ -397,10 +412,12 @@ defaultMainStreaming tree = do
           }
   let tree' =
         localOption pkgRootOpt $
-          localOption (TMStoreOption (Just store)) $
-            localOption (storeRecorder store) $
-              localOption (TestMapRef (Just testMapRef)) $
-                localOption (StreamingEnabledRef (Just enabledRef)) $
-                  localOption (OutputLockRef (Just outputLock)) $
-                    localOption traceRec tree
+          localOption (QCStatsStoreOption (Just qcStatsStore)) $
+            localOption (storeQCStatsRecorder qcStatsStore) $
+              localOption (TMStoreOption (Just store)) $
+                localOption (storeRecorder store) $
+                  localOption (TestMapRef (Just testMapRef)) $
+                    localOption (StreamingEnabledRef (Just enabledRef)) $
+                      localOption (OutputLockRef (Just outputLock)) $
+                        localOption traceRec tree
   defaultMainWithIngredients streamingIngredients tree'

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming.hs
@@ -12,7 +12,7 @@ import Control.Monad (when)
 import Convex.Tasty.Streaming.QCStats (
   QCStatsRecorder,
   QCStatsStoreOption (..),
-  lookupQCStatsBySrcLoc,
+  lookupQCStatsByTestInfo,
   newQCStatsStore,
   storeQCStatsRecorder,
  )
@@ -237,8 +237,8 @@ streamingJsonReporter = TestReporter
           mSummary <- case mStore of
             Just store -> lookupThreatModelSummary store key
             Nothing -> pure Nothing
-          mMonitoring <- case (mQCStatsStore, testInfo >>= tiSrcLoc) of
-            (Just store, Just loc) -> lookupQCStatsBySrcLoc store loc
+          mMonitoring <- case (mQCStatsStore, testInfo) of
+            (Just store, Just ti) -> lookupQCStatsByTestInfo store ti
             _ -> pure Nothing
 
           -- Emit test_done

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming/QCStats.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming/QCStats.hs
@@ -64,17 +64,17 @@ lookupQCStats (QCStatsStore ref) key =
   Map.lookup key <$> readIORef ref
 
 lookupQCStatsByTestInfo :: QCStatsStore -> TestInfo -> IO (Maybe MonitoringStats)
-lookupQCStatsByTestInfo store ti =
+lookupQCStatsByTestInfo (QCStatsStore ref) ti =
   case tiSrcLoc ti of
     Nothing -> pure Nothing
     Just loc -> do
+      m <- readIORef ref
       let fullKey = mkQCStatsKey loc (tiPath ti) (tiName ti)
-      mStats <- lookupQCStats store fullKey
-      case mStats of
-        Just stats -> pure (Just stats)
-        -- Backward-compatible fallback while recorder-side path propagation
-        -- is not yet universally available.
-        Nothing -> lookupQCStats store (mkQCStatsKey loc [] (tiName ti))
+          fallbackKey = mkQCStatsKey loc [] (tiName ti)
+      pure $
+        case Map.lookup fullKey m of
+          Just stats -> Just stats
+          Nothing -> Map.lookup fallbackKey m
 
 recordQCStatsFromState :: QCStatsRecorder -> Maybe SrcLocRange -> String -> QS.State -> IO ()
 recordQCStatsFromState recorder mLoc testName st =

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming/QCStats.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming/QCStats.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Convex.Tasty.Streaming.QCStats (
+  QCStatsKey (..),
   QCStatsStore,
   QCStatsRecorder (..),
   QCStatsStoreOption (..),
-  QCStatsPathIndex (..),
   newQCStatsStore,
   storeQCStatsRecorder,
-  mkQCStatsPathIndex,
-  resolveQCStatsPath,
   mkQCStatsKey,
   lookupQCStats,
   lookupQCStatsByTestInfo,
@@ -35,15 +33,37 @@ import Data.Text qualified as T
 import Test.QuickCheck.State qualified as QS
 import Test.Tasty.Options (IsOption (..))
 
-newtype QCStatsStore = QCStatsStore (IORef (Map String MonitoringStats))
+data QCStatsKey = QCStatsKey
+  { qskSrcLoc :: SrcLocRange
+  , qskTestName :: T.Text
+  }
+  deriving (Eq, Show)
+
+instance Ord QCStatsKey where
+  compare QCStatsKey{qskSrcLoc = lhsLoc, qskTestName = lhsName} QCStatsKey{qskSrcLoc = rhsLoc, qskTestName = rhsName} =
+    compare
+      ( slrFile lhsLoc
+      , slrStartLine lhsLoc
+      , slrStartCol lhsLoc
+      , slrEndLine lhsLoc
+      , slrEndCol lhsLoc
+      , lhsName
+      )
+      ( slrFile rhsLoc
+      , slrStartLine rhsLoc
+      , slrStartCol rhsLoc
+      , slrEndLine rhsLoc
+      , slrEndCol rhsLoc
+      , rhsName
+      )
+
+newtype QCStatsStore = QCStatsStore (IORef (Map QCStatsKey MonitoringStats))
 
 newtype QCStatsRecorder = QCStatsRecorder
-  { qcRecordStats :: String -> MonitoringStats -> IO ()
+  { qcRecordStats :: QCStatsKey -> MonitoringStats -> IO ()
   }
 
 newtype QCStatsStoreOption = QCStatsStoreOption (Maybe QCStatsStore)
-
-newtype QCStatsPathIndex = QCStatsPathIndex (Map String (Maybe [T.Text]))
 
 instance IsOption QCStatsRecorder where
   defaultValue = QCStatsRecorder (\_ _ -> pure ())
@@ -57,12 +77,6 @@ instance IsOption QCStatsStoreOption where
   optionName = Tagged "qc-stats-store"
   optionHelp = Tagged "internal: quickcheck monitoring stats store handle"
 
-instance IsOption QCStatsPathIndex where
-  defaultValue = QCStatsPathIndex Map.empty
-  parseValue = const Nothing
-  optionName = Tagged "qc-stats-path-index"
-  optionHelp = Tagged "internal: quickcheck monitoring stats path resolver"
-
 newQCStatsStore :: IO QCStatsStore
 newQCStatsStore = QCStatsStore <$> newIORef Map.empty
 
@@ -70,7 +84,7 @@ storeQCStatsRecorder :: QCStatsStore -> QCStatsRecorder
 storeQCStatsRecorder (QCStatsStore ref) = QCStatsRecorder $ \key stats ->
   atomicModifyIORef' ref $ \m -> (Map.insert key stats m, ())
 
-lookupQCStats :: QCStatsStore -> String -> IO (Maybe MonitoringStats)
+lookupQCStats :: QCStatsStore -> QCStatsKey -> IO (Maybe MonitoringStats)
 lookupQCStats (QCStatsStore ref) key =
   Map.lookup key <$> readIORef ref
 
@@ -80,52 +94,15 @@ lookupQCStatsByTestInfo (QCStatsStore ref) ti =
     Nothing -> pure Nothing
     Just loc -> do
       m <- readIORef ref
-      pure $ Map.lookup (mkQCStatsKey loc (tiPath ti) (tiName ti)) m
+      pure $ Map.lookup (mkQCStatsKey loc (tiName ti)) m
 
-mkQCStatsPathIndex :: [TestInfo] -> QCStatsPathIndex
-mkQCStatsPathIndex infos = QCStatsPathIndex (foldr insertInfo Map.empty infos)
- where
-  insertInfo ti m =
-    case tiSrcLoc ti of
-      Nothing -> m
-      Just loc ->
-        let identity = mkQCStatsKey loc [] (tiName ti)
-            path = tiPath ti
-         in case Map.lookup identity m of
-              Nothing -> Map.insert identity (Just path) m
-              Just (Just existingPath)
-                | existingPath == path -> m
-                | otherwise -> Map.insert identity Nothing m
-              Just Nothing -> m
+mkQCStatsKey :: SrcLocRange -> T.Text -> QCStatsKey
+mkQCStatsKey loc testName = QCStatsKey{qskSrcLoc = loc, qskTestName = testName}
 
-resolveQCStatsPath :: QCStatsPathIndex -> Maybe SrcLocRange -> String -> Maybe [T.Text]
-resolveQCStatsPath (QCStatsPathIndex index) mLoc testName = do
-  loc <- mLoc
-  Map.lookup (mkQCStatsKey loc [] (T.pack testName)) index >>= id
-
-recordQCStatsFromState :: QCStatsRecorder -> Maybe SrcLocRange -> Maybe [T.Text] -> String -> QS.State -> IO ()
-recordQCStatsFromState recorder mLoc mPath testName st =
-  for_ ((,) <$> mLoc <*> mPath) $ \(loc, path) ->
-    qcRecordStats recorder (mkQCStatsKey loc path (T.pack testName)) (fromState st)
-
-srcLocKey :: SrcLocRange -> String
-srcLocKey SrcLocRange{slrFile, slrStartLine, slrStartCol, slrEndLine, slrEndCol} =
-  T.unpack slrFile
-    <> ":"
-    <> show slrStartLine
-    <> ":"
-    <> show slrStartCol
-    <> ":"
-    <> show slrEndLine
-    <> ":"
-    <> show slrEndCol
-
-mkQCStatsKey :: SrcLocRange -> [T.Text] -> T.Text -> String
-mkQCStatsKey loc pathParts testName =
-  srcLocKey loc <> "#" <> concatMap encodePart (pathParts <> [testName])
- where
-  encodePart part =
-    show (T.length part) <> ":" <> T.unpack part <> "|"
+recordQCStatsFromState :: QCStatsRecorder -> Maybe SrcLocRange -> String -> QS.State -> IO ()
+recordQCStatsFromState recorder mLoc testName st =
+  for_ mLoc $ \loc ->
+    qcRecordStats recorder (mkQCStatsKey loc (T.pack testName)) (fromState st)
 
 fromState :: QS.State -> MonitoringStats
 fromState st =

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming/QCStats.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming/QCStats.hs
@@ -4,8 +4,11 @@ module Convex.Tasty.Streaming.QCStats (
   QCStatsStore,
   QCStatsRecorder (..),
   QCStatsStoreOption (..),
+  QCStatsPathIndex (..),
   newQCStatsStore,
   storeQCStatsRecorder,
+  mkQCStatsPathIndex,
+  resolveQCStatsPath,
   mkQCStatsKey,
   lookupQCStats,
   lookupQCStatsByTestInfo,
@@ -40,6 +43,8 @@ newtype QCStatsRecorder = QCStatsRecorder
 
 newtype QCStatsStoreOption = QCStatsStoreOption (Maybe QCStatsStore)
 
+newtype QCStatsPathIndex = QCStatsPathIndex (Map String (Maybe [T.Text]))
+
 instance IsOption QCStatsRecorder where
   defaultValue = QCStatsRecorder (\_ _ -> pure ())
   parseValue = const Nothing
@@ -51,6 +56,12 @@ instance IsOption QCStatsStoreOption where
   parseValue = const Nothing
   optionName = Tagged "qc-stats-store"
   optionHelp = Tagged "internal: quickcheck monitoring stats store handle"
+
+instance IsOption QCStatsPathIndex where
+  defaultValue = QCStatsPathIndex Map.empty
+  parseValue = const Nothing
+  optionName = Tagged "qc-stats-path-index"
+  optionHelp = Tagged "internal: quickcheck monitoring stats path resolver"
 
 newQCStatsStore :: IO QCStatsStore
 newQCStatsStore = QCStatsStore <$> newIORef Map.empty
@@ -69,17 +80,33 @@ lookupQCStatsByTestInfo (QCStatsStore ref) ti =
     Nothing -> pure Nothing
     Just loc -> do
       m <- readIORef ref
-      let fullKey = mkQCStatsKey loc (tiPath ti) (tiName ti)
-          fallbackKey = mkQCStatsKey loc [] (tiName ti)
-      pure $
-        case Map.lookup fullKey m of
-          Just stats -> Just stats
-          Nothing -> Map.lookup fallbackKey m
+      pure $ Map.lookup (mkQCStatsKey loc (tiPath ti) (tiName ti)) m
 
-recordQCStatsFromState :: QCStatsRecorder -> Maybe SrcLocRange -> String -> QS.State -> IO ()
-recordQCStatsFromState recorder mLoc testName st =
-  for_ mLoc $ \loc ->
-    qcRecordStats recorder (mkQCStatsKey loc [] (T.pack testName)) (fromState st)
+mkQCStatsPathIndex :: [TestInfo] -> QCStatsPathIndex
+mkQCStatsPathIndex infos = QCStatsPathIndex (foldr insertInfo Map.empty infos)
+ where
+  insertInfo ti m =
+    case tiSrcLoc ti of
+      Nothing -> m
+      Just loc ->
+        let identity = mkQCStatsKey loc [] (tiName ti)
+            path = tiPath ti
+         in case Map.lookup identity m of
+              Nothing -> Map.insert identity (Just path) m
+              Just (Just existingPath)
+                | existingPath == path -> m
+                | otherwise -> Map.insert identity Nothing m
+              Just Nothing -> m
+
+resolveQCStatsPath :: QCStatsPathIndex -> Maybe SrcLocRange -> String -> Maybe [T.Text]
+resolveQCStatsPath (QCStatsPathIndex index) mLoc testName = do
+  loc <- mLoc
+  Map.lookup (mkQCStatsKey loc [] (T.pack testName)) index >>= id
+
+recordQCStatsFromState :: QCStatsRecorder -> Maybe SrcLocRange -> Maybe [T.Text] -> String -> QS.State -> IO ()
+recordQCStatsFromState recorder mLoc mPath testName st =
+  for_ ((,) <$> mLoc <*> mPath) $ \(loc, path) ->
+    qcRecordStats recorder (mkQCStatsKey loc path (T.pack testName)) (fromState st)
 
 srcLocKey :: SrcLocRange -> String
 srcLocKey SrcLocRange{slrFile, slrStartLine, slrStartCol, slrEndLine, slrEndCol} =

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming/QCStats.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming/QCStats.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Convex.Tasty.Streaming.QCStats (
+  QCStatsStore,
+  QCStatsRecorder (..),
+  QCStatsStoreOption (..),
+  newQCStatsStore,
+  storeQCStatsRecorder,
+  lookupQCStats,
+  lookupQCStatsBySrcLoc,
+  recordQCStatsFromState,
+) where
+
+import Convex.Tasty.Streaming.SrcLoc (SrcLocRange (..))
+import Convex.Tasty.Streaming.Types (
+  MonitoringClassStat (..),
+  MonitoringLabelStat (..),
+  MonitoringStats (..),
+  MonitoringTableEntry (..),
+  MonitoringTableStat (..),
+ )
+import Data.Foldable (for_)
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
+import Data.List (sortOn)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Ord (Down (..))
+import Data.Tagged (Tagged (..))
+import Data.Text qualified as T
+import Test.QuickCheck.State qualified as QS
+import Test.Tasty.Options (IsOption (..))
+
+newtype QCStatsStore = QCStatsStore (IORef (Map String MonitoringStats))
+
+newtype QCStatsRecorder = QCStatsRecorder
+  { qcRecordStats :: String -> MonitoringStats -> IO ()
+  }
+
+newtype QCStatsStoreOption = QCStatsStoreOption (Maybe QCStatsStore)
+
+instance IsOption QCStatsRecorder where
+  defaultValue = QCStatsRecorder (\_ _ -> pure ())
+  parseValue = const Nothing
+  optionName = Tagged "qc-stats-recorder"
+  optionHelp = Tagged "internal: quickcheck monitoring stats recorder"
+
+instance IsOption QCStatsStoreOption where
+  defaultValue = QCStatsStoreOption Nothing
+  parseValue = const Nothing
+  optionName = Tagged "qc-stats-store"
+  optionHelp = Tagged "internal: quickcheck monitoring stats store handle"
+
+newQCStatsStore :: IO QCStatsStore
+newQCStatsStore = QCStatsStore <$> newIORef Map.empty
+
+storeQCStatsRecorder :: QCStatsStore -> QCStatsRecorder
+storeQCStatsRecorder (QCStatsStore ref) = QCStatsRecorder $ \key stats ->
+  atomicModifyIORef' ref $ \m -> (Map.insert key stats m, ())
+
+lookupQCStats :: QCStatsStore -> String -> IO (Maybe MonitoringStats)
+lookupQCStats (QCStatsStore ref) key =
+  Map.lookup key <$> readIORef ref
+
+lookupQCStatsBySrcLoc :: QCStatsStore -> SrcLocRange -> IO (Maybe MonitoringStats)
+lookupQCStatsBySrcLoc store loc =
+  lookupQCStats store (srcLocKey loc)
+
+recordQCStatsFromState :: QCStatsRecorder -> Maybe SrcLocRange -> QS.State -> IO ()
+recordQCStatsFromState recorder mLoc st =
+  for_ mLoc $ \loc ->
+    qcRecordStats recorder (srcLocKey loc) (fromState st)
+
+srcLocKey :: SrcLocRange -> String
+srcLocKey SrcLocRange{slrFile, slrStartLine, slrStartCol, slrEndLine, slrEndCol} =
+  T.unpack slrFile
+    <> ":"
+    <> show slrStartLine
+    <> ":"
+    <> show slrStartCol
+    <> ":"
+    <> show slrEndLine
+    <> ":"
+    <> show slrEndCol
+
+fromState :: QS.State -> MonitoringStats
+fromState st =
+  MonitoringStats
+    { msNumTests = total
+    , msNumDiscarded = QS.numDiscardedTests st
+    , msLabels =
+        sortOn
+          (Down . mlsCount)
+          [ MonitoringLabelStat
+              { mlsLabels = map T.pack names
+              , mlsCount = count
+              , mlsPercent = pct count
+              }
+          | (names, count) <- Map.toList (QS.labels st)
+          ]
+    , msClasses =
+        sortOn
+          (Down . mcsCount)
+          [ MonitoringClassStat
+              { mcsName = T.pack className
+              , mcsCount = count
+              , mcsPercent = pct count
+              }
+          | (className, count) <- Map.toList (QS.classes st)
+          ]
+    , msTables =
+        [ MonitoringTableStat
+            { mtsName = T.pack tableName
+            , mtsEntries =
+                sortOn
+                  (Down . mteCount)
+                  [ MonitoringTableEntry
+                      { mteValue = T.pack entryName
+                      , mteCount = count
+                      }
+                  | (entryName, count) <- Map.toList tableEntries
+                  ]
+            }
+        | (tableName, tableEntries) <- Map.toList (QS.tables st)
+        ]
+    }
+ where
+  total = QS.numSuccessTests st
+  pct count
+    | total <= 0 = 0
+    | otherwise = (fromIntegral count * 100) / fromIntegral total

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming/QCStats.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming/QCStats.hs
@@ -6,8 +6,9 @@ module Convex.Tasty.Streaming.QCStats (
   QCStatsStoreOption (..),
   newQCStatsStore,
   storeQCStatsRecorder,
+  mkQCStatsKey,
   lookupQCStats,
-  lookupQCStatsBySrcLoc,
+  lookupQCStatsByTestInfo,
   recordQCStatsFromState,
 ) where
 
@@ -18,6 +19,7 @@ import Convex.Tasty.Streaming.Types (
   MonitoringStats (..),
   MonitoringTableEntry (..),
   MonitoringTableStat (..),
+  TestInfo (..),
  )
 import Data.Foldable (for_)
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
@@ -61,14 +63,23 @@ lookupQCStats :: QCStatsStore -> String -> IO (Maybe MonitoringStats)
 lookupQCStats (QCStatsStore ref) key =
   Map.lookup key <$> readIORef ref
 
-lookupQCStatsBySrcLoc :: QCStatsStore -> SrcLocRange -> IO (Maybe MonitoringStats)
-lookupQCStatsBySrcLoc store loc =
-  lookupQCStats store (srcLocKey loc)
+lookupQCStatsByTestInfo :: QCStatsStore -> TestInfo -> IO (Maybe MonitoringStats)
+lookupQCStatsByTestInfo store ti =
+  case tiSrcLoc ti of
+    Nothing -> pure Nothing
+    Just loc -> do
+      let fullKey = mkQCStatsKey loc (tiPath ti) (tiName ti)
+      mStats <- lookupQCStats store fullKey
+      case mStats of
+        Just stats -> pure (Just stats)
+        -- Backward-compatible fallback while recorder-side path propagation
+        -- is not yet universally available.
+        Nothing -> lookupQCStats store (mkQCStatsKey loc [] (tiName ti))
 
-recordQCStatsFromState :: QCStatsRecorder -> Maybe SrcLocRange -> QS.State -> IO ()
-recordQCStatsFromState recorder mLoc st =
+recordQCStatsFromState :: QCStatsRecorder -> Maybe SrcLocRange -> String -> QS.State -> IO ()
+recordQCStatsFromState recorder mLoc testName st =
   for_ mLoc $ \loc ->
-    qcRecordStats recorder (srcLocKey loc) (fromState st)
+    qcRecordStats recorder (mkQCStatsKey loc [] (T.pack testName)) (fromState st)
 
 srcLocKey :: SrcLocRange -> String
 srcLocKey SrcLocRange{slrFile, slrStartLine, slrStartCol, slrEndLine, slrEndCol} =
@@ -81,6 +92,13 @@ srcLocKey SrcLocRange{slrFile, slrStartLine, slrStartCol, slrEndLine, slrEndCol}
     <> show slrEndLine
     <> ":"
     <> show slrEndCol
+
+mkQCStatsKey :: SrcLocRange -> [T.Text] -> T.Text -> String
+mkQCStatsKey loc pathParts testName =
+  srcLocKey loc <> "#" <> concatMap encodePart (pathParts <> [testName])
+ where
+  encodePart part =
+    show (T.length part) <> ":" <> T.unpack part <> "|"
 
 fromState :: QS.State -> MonitoringStats
 fromState st =

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming/QCStats.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming/QCStats.hs
@@ -37,25 +37,7 @@ data QCStatsKey = QCStatsKey
   { qskSrcLoc :: SrcLocRange
   , qskTestName :: T.Text
   }
-  deriving (Eq, Show)
-
-instance Ord QCStatsKey where
-  compare QCStatsKey{qskSrcLoc = lhsLoc, qskTestName = lhsName} QCStatsKey{qskSrcLoc = rhsLoc, qskTestName = rhsName} =
-    compare
-      ( slrFile lhsLoc
-      , slrStartLine lhsLoc
-      , slrStartCol lhsLoc
-      , slrEndLine lhsLoc
-      , slrEndCol lhsLoc
-      , lhsName
-      )
-      ( slrFile rhsLoc
-      , slrStartLine rhsLoc
-      , slrStartCol rhsLoc
-      , slrEndLine rhsLoc
-      , slrEndCol rhsLoc
-      , rhsName
-      )
+  deriving (Eq, Ord, Show)
 
 newtype QCStatsStore = QCStatsStore (IORef (Map QCStatsKey MonitoringStats))
 

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming/SrcLoc.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming/SrcLoc.hs
@@ -84,7 +84,7 @@ data SrcLocRange = SrcLocRange
   , slrEndLine :: !Int
   , slrEndCol :: !Int
   }
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 instance ToJSON SrcLocRange where
   toJSON SrcLocRange{..} =

--- a/src/tasty-streaming/lib/Convex/Tasty/Streaming/Types.hs
+++ b/src/tasty-streaming/lib/Convex/Tasty/Streaming/Types.hs
@@ -3,6 +3,11 @@ module Convex.Tasty.Streaming.Types (
   TestInfo (..),
   TestOutcome (..),
   FailureInfo (..),
+  MonitoringStats (..),
+  MonitoringLabelStat (..),
+  MonitoringClassStat (..),
+  MonitoringTableStat (..),
+  MonitoringTableEntry (..),
 ) where
 
 import Convex.Tasty.Streaming.SrcLoc (SrcLocRange)
@@ -67,6 +72,116 @@ instance FromJSON FailureInfo where
       <$> o .: "reason"
       <*> o .: "message"
 
+data MonitoringLabelStat = MonitoringLabelStat
+  { mlsLabels :: ![Text]
+  , mlsCount :: !Int
+  , mlsPercent :: !Double
+  }
+  deriving (Eq, Show, Generic)
+
+instance ToJSON MonitoringLabelStat where
+  toJSON (MonitoringLabelStat labels count percent) =
+    object
+      [ "labels" .= labels
+      , "count" .= count
+      , "percent" .= percent
+      ]
+
+instance FromJSON MonitoringLabelStat where
+  parseJSON = withObject "MonitoringLabelStat" $ \o ->
+    MonitoringLabelStat
+      <$> o .: "labels"
+      <*> o .: "count"
+      <*> o .: "percent"
+
+data MonitoringClassStat = MonitoringClassStat
+  { mcsName :: !Text
+  , mcsCount :: !Int
+  , mcsPercent :: !Double
+  }
+  deriving (Eq, Show, Generic)
+
+instance ToJSON MonitoringClassStat where
+  toJSON (MonitoringClassStat name count percent) =
+    object
+      [ "name" .= name
+      , "count" .= count
+      , "percent" .= percent
+      ]
+
+instance FromJSON MonitoringClassStat where
+  parseJSON = withObject "MonitoringClassStat" $ \o ->
+    MonitoringClassStat
+      <$> o .: "name"
+      <*> o .: "count"
+      <*> o .: "percent"
+
+data MonitoringTableEntry = MonitoringTableEntry
+  { mteValue :: !Text
+  , mteCount :: !Int
+  }
+  deriving (Eq, Show, Generic)
+
+instance ToJSON MonitoringTableEntry where
+  toJSON (MonitoringTableEntry value count) =
+    object
+      [ "value" .= value
+      , "count" .= count
+      ]
+
+instance FromJSON MonitoringTableEntry where
+  parseJSON = withObject "MonitoringTableEntry" $ \o ->
+    MonitoringTableEntry
+      <$> o .: "value"
+      <*> o .: "count"
+
+data MonitoringTableStat = MonitoringTableStat
+  { mtsName :: !Text
+  , mtsEntries :: ![MonitoringTableEntry]
+  }
+  deriving (Eq, Show, Generic)
+
+instance ToJSON MonitoringTableStat where
+  toJSON (MonitoringTableStat name entries) =
+    object
+      [ "name" .= name
+      , "entries" .= entries
+      ]
+
+instance FromJSON MonitoringTableStat where
+  parseJSON = withObject "MonitoringTableStat" $ \o ->
+    MonitoringTableStat
+      <$> o .: "name"
+      <*> o .: "entries"
+
+data MonitoringStats = MonitoringStats
+  { msNumTests :: !Int
+  , msNumDiscarded :: !Int
+  , msLabels :: ![MonitoringLabelStat]
+  , msClasses :: ![MonitoringClassStat]
+  , msTables :: ![MonitoringTableStat]
+  }
+  deriving (Eq, Show, Generic)
+
+instance ToJSON MonitoringStats where
+  toJSON (MonitoringStats numTests numDiscarded labels classes tables) =
+    object
+      [ "numTests" .= numTests
+      , "numDiscarded" .= numDiscarded
+      , "labels" .= labels
+      , "classes" .= classes
+      , "tables" .= tables
+      ]
+
+instance FromJSON MonitoringStats where
+  parseJSON = withObject "MonitoringStats" $ \o ->
+    MonitoringStats
+      <$> o .: "numTests"
+      <*> o .: "numDiscarded"
+      <*> o .: "labels"
+      <*> o .: "classes"
+      <*> o .: "tables"
+
 -- | A streaming event emitted as a single NDJSON line
 data Event
   = SuiteStarted
@@ -92,6 +207,7 @@ data Event
       , edDuration :: !Double
       , edDescription :: !Text
       , edThreatModel :: !(Maybe ThreatModelSummary)
+      , edMonitoringStats :: !(Maybe MonitoringStats)
       }
   | TestTrace
       { ettTestId :: !Int
@@ -124,7 +240,7 @@ instance ToJSON Event where
       , "message" .= msg
       , "percent" .= pct
       ]
-  toJSON (TestDone i outcome dur desc mTm) =
+  toJSON (TestDone i outcome dur desc mTm mMonitoring) =
     object $
       [ "event" .= ("test_done" :: Text)
       , "id" .= i
@@ -133,6 +249,7 @@ instance ToJSON Event where
       ]
         <> outcomeFields outcome
         <> threatModelFields mTm
+        <> monitoringFields mMonitoring
    where
     outcomeFields TestSuccess = ["success" .= True]
     outcomeFields (TestFailure fi) =
@@ -141,6 +258,8 @@ instance ToJSON Event where
       ]
     threatModelFields :: Maybe ThreatModelSummary -> [Pair]
     threatModelFields = maybe [] (\s -> ["threat_model" .= s])
+    monitoringFields :: Maybe MonitoringStats -> [Pair]
+    monitoringFields = maybe [] (\s -> ["monitoring_stats" .= s])
   toJSON (TestTrace i cat trace) =
     object
       [ "event" .= ("test_trace" :: Text)
@@ -181,7 +300,8 @@ instance FromJSON Event where
             then pure TestSuccess
             else TestFailure <$> o .: "failure"
         mTm <- o .:? "threat_model"
-        pure (TestDone eid outcome dur desc mTm)
+        mMonitoring <- o .:? "monitoring_stats"
+        pure (TestDone eid outcome dur desc mTm mMonitoring)
       "test_trace" ->
         TestTrace
           <$> o .: "id"

--- a/src/tasty-streaming/schema/streaming-events.schema.json
+++ b/src/tasty-streaming/schema/streaming-events.schema.json
@@ -115,6 +115,9 @@
                         "id": {
                             "type": "integer"
                         },
+                        "monitoring_stats": {
+                            "$ref": "#/$defs/MonitoringStats"
+                        },
                         "success": {
                             "type": "boolean"
                         },
@@ -285,6 +288,118 @@
                 "status",
                 "transitions",
                 "threatModels"
+            ],
+            "type": "object"
+        },
+        "MonitoringClassStat": {
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "percent": {
+                    "format": "double",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "name",
+                "count",
+                "percent"
+            ],
+            "type": "object"
+        },
+        "MonitoringLabelStat": {
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "labels": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "percent": {
+                    "format": "double",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "labels",
+                "count",
+                "percent"
+            ],
+            "type": "object"
+        },
+        "MonitoringStats": {
+            "properties": {
+                "classes": {
+                    "items": {
+                        "$ref": "#/$defs/MonitoringClassStat"
+                    },
+                    "type": "array"
+                },
+                "labels": {
+                    "items": {
+                        "$ref": "#/$defs/MonitoringLabelStat"
+                    },
+                    "type": "array"
+                },
+                "numDiscarded": {
+                    "type": "integer"
+                },
+                "numTests": {
+                    "type": "integer"
+                },
+                "tables": {
+                    "items": {
+                        "$ref": "#/$defs/MonitoringTableStat"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "numTests",
+                "numDiscarded",
+                "labels",
+                "classes",
+                "tables"
+            ],
+            "type": "object"
+        },
+        "MonitoringTableEntry": {
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "value",
+                "count"
+            ],
+            "type": "object"
+        },
+        "MonitoringTableStat": {
+            "properties": {
+                "entries": {
+                    "items": {
+                        "$ref": "#/$defs/MonitoringTableEntry"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "entries"
             ],
             "type": "object"
         },
@@ -1202,6 +1317,9 @@
                 },
                 "id": {
                     "type": "integer"
+                },
+                "monitoring_stats": {
+                    "$ref": "#/$defs/MonitoringStats"
                 },
                 "success": {
                     "type": "boolean"

--- a/src/tasty-streaming/test/Convex/Tasty/SrcLocSpec.hs
+++ b/src/tasty-streaming/test/Convex/Tasty/SrcLocSpec.hs
@@ -16,7 +16,9 @@ import Convex.Tasty.Streaming.QCStats (
   QCStatsRecorder (..),
   lookupQCStatsByTestInfo,
   mkQCStatsKey,
+  mkQCStatsPathIndex,
   newQCStatsStore,
+  resolveQCStatsPath,
   storeQCStatsRecorder,
  )
 import Convex.Tasty.Streaming.SrcLoc (
@@ -55,7 +57,8 @@ tests =
     , testCase "MonitoringStats round-trip" monitoringStatsRoundTrip
     , testCase "TestDone round-trip with monitoring_stats" testDoneRoundTripWithMonitoring
     , testCase "QC stats key differs across test identities" qcStatsKeyDiffersAcrossTestIdentities
-    , testCase "QC stats lookup uses TestInfo fallback" qcStatsLookupUsesTestInfoFallback
+    , testCase "QC stats lookup requires full TestInfo identity" qcStatsLookupRequiresFullIdentity
+    , testCase "QC stats path resolver marks ambiguous identities" qcStatsPathResolverAmbiguousIdentity
     , testCase "callerPackageRoot resolves to convex-tasty-streaming" callerPackageRootResolvesToThisPackage
     , testCase "findPackageRootFromFile finds convex-tasty-streaming" findPackageRootFromFileFindsThisPackage
     ]
@@ -393,8 +396,8 @@ qcStatsKeyDiffersAcrossTestIdentities = do
   assertBool "Different groups must produce different keys" (keyA /= keyB)
   assertBool "Different test names must produce different keys" (keyA /= keyC)
 
-qcStatsLookupUsesTestInfoFallback :: Assertion
-qcStatsLookupUsesTestInfoFallback = do
+qcStatsLookupRequiresFullIdentity :: Assertion
+qcStatsLookupRequiresFullIdentity = do
   store <- newQCStatsStore
   let recorder = storeQCStatsRecorder store
       loc =
@@ -420,10 +423,44 @@ qcStatsLookupUsesTestInfoFallback = do
           , tiPath = ["group"]
           , tiSrcLoc = Just loc
           }
-  -- Simulate recorder-side write when only test name is available.
-  qcRecordStats recorder (mkQCStatsKey loc [] "leaf") stats
+  qcRecordStats recorder (mkQCStatsKey loc ["group"] "leaf") stats
   mFound <- lookupQCStatsByTestInfo store ti
-  assertEqual "lookup should find stats via name-only fallback" (Just stats) mFound
+  assertEqual "lookup should find stats for exact full identity" (Just stats) mFound
+
+  qcRecordStats recorder (mkQCStatsKey loc [] "leaf") stats
+  mStill <- lookupQCStatsByTestInfo store ti
+  assertEqual "lookup should ignore fallback identity writes" (Just stats) mStill
+
+qcStatsPathResolverAmbiguousIdentity :: Assertion
+qcStatsPathResolverAmbiguousIdentity = do
+  let loc =
+        SrcLocRange
+          { slrFile = "src/Foo.hs"
+          , slrStartLine = 10
+          , slrStartCol = 5
+          , slrEndLine = 10
+          , slrEndCol = 13
+          }
+      tiA =
+        TestInfo
+          { tiId = 1
+          , tiName = "leaf"
+          , tiPath = ["group-a"]
+          , tiSrcLoc = Just loc
+          }
+      tiB =
+        TestInfo
+          { tiId = 2
+          , tiName = "leaf"
+          , tiPath = ["group-b"]
+          , tiSrcLoc = Just loc
+          }
+      resolver = mkQCStatsPathIndex [tiA, tiB]
+
+  assertEqual
+    "resolver should refuse ambiguous srcLoc/name identities"
+    Nothing
+    (resolveQCStatsPath resolver (Just loc) "leaf")
 
 -- ---------------------------------------------------------------------------
 -- 11. callerPackageRoot end-to-end: when invoked from inside this test

--- a/src/tasty-streaming/test/Convex/Tasty/SrcLocSpec.hs
+++ b/src/tasty-streaming/test/Convex/Tasty/SrcLocSpec.hs
@@ -16,9 +16,7 @@ import Convex.Tasty.Streaming.QCStats (
   QCStatsRecorder (..),
   lookupQCStatsByTestInfo,
   mkQCStatsKey,
-  mkQCStatsPathIndex,
   newQCStatsStore,
-  resolveQCStatsPath,
   storeQCStatsRecorder,
  )
 import Convex.Tasty.Streaming.SrcLoc (
@@ -57,8 +55,7 @@ tests =
     , testCase "MonitoringStats round-trip" monitoringStatsRoundTrip
     , testCase "TestDone round-trip with monitoring_stats" testDoneRoundTripWithMonitoring
     , testCase "QC stats key differs across test identities" qcStatsKeyDiffersAcrossTestIdentities
-    , testCase "QC stats lookup requires full TestInfo identity" qcStatsLookupRequiresFullIdentity
-    , testCase "QC stats path resolver marks ambiguous identities" qcStatsPathResolverAmbiguousIdentity
+    , testCase "QC stats lookup uses srcLoc and test name" qcStatsLookupRequiresFullIdentity
     , testCase "callerPackageRoot resolves to convex-tasty-streaming" callerPackageRootResolvesToThisPackage
     , testCase "findPackageRootFromFile finds convex-tasty-streaming" findPackageRootFromFileFindsThisPackage
     ]
@@ -390,11 +387,20 @@ qcStatsKeyDiffersAcrossTestIdentities = do
           , slrEndLine = 10
           , slrEndCol = 13
           }
-      keyA = mkQCStatsKey loc ["group-a"] "leaf"
-      keyB = mkQCStatsKey loc ["group-b"] "leaf"
-      keyC = mkQCStatsKey loc [] "leaf-2"
-  assertBool "Different groups must produce different keys" (keyA /= keyB)
-  assertBool "Different test names must produce different keys" (keyA /= keyC)
+      keyA = mkQCStatsKey loc "leaf"
+      keyB = mkQCStatsKey loc "leaf-2"
+      keyC =
+        mkQCStatsKey
+          SrcLocRange
+            { slrFile = "src/Other.hs"
+            , slrStartLine = 10
+            , slrStartCol = 5
+            , slrEndLine = 10
+            , slrEndCol = 13
+            }
+          "leaf"
+  assertBool "Different test names must produce different keys" (keyA /= keyB)
+  assertBool "Different source locations must produce different keys" (keyA /= keyC)
 
 qcStatsLookupRequiresFullIdentity :: Assertion
 qcStatsLookupRequiresFullIdentity = do
@@ -423,44 +429,13 @@ qcStatsLookupRequiresFullIdentity = do
           , tiPath = ["group"]
           , tiSrcLoc = Just loc
           }
-  qcRecordStats recorder (mkQCStatsKey loc ["group"] "leaf") stats
+  qcRecordStats recorder (mkQCStatsKey loc "leaf") stats
   mFound <- lookupQCStatsByTestInfo store ti
   assertEqual "lookup should find stats for exact full identity" (Just stats) mFound
 
-  qcRecordStats recorder (mkQCStatsKey loc [] "leaf") stats
+  qcRecordStats recorder (mkQCStatsKey loc "leaf") stats
   mStill <- lookupQCStatsByTestInfo store ti
-  assertEqual "lookup should ignore fallback identity writes" (Just stats) mStill
-
-qcStatsPathResolverAmbiguousIdentity :: Assertion
-qcStatsPathResolverAmbiguousIdentity = do
-  let loc =
-        SrcLocRange
-          { slrFile = "src/Foo.hs"
-          , slrStartLine = 10
-          , slrStartCol = 5
-          , slrEndLine = 10
-          , slrEndCol = 13
-          }
-      tiA =
-        TestInfo
-          { tiId = 1
-          , tiName = "leaf"
-          , tiPath = ["group-a"]
-          , tiSrcLoc = Just loc
-          }
-      tiB =
-        TestInfo
-          { tiId = 2
-          , tiName = "leaf"
-          , tiPath = ["group-b"]
-          , tiSrcLoc = Just loc
-          }
-      resolver = mkQCStatsPathIndex [tiA, tiB]
-
-  assertEqual
-    "resolver should refuse ambiguous srcLoc/name identities"
-    Nothing
-    (resolveQCStatsPath resolver (Just loc) "leaf")
+  assertEqual "lookup should remain stable for repeated writes" (Just stats) mStill
 
 -- ---------------------------------------------------------------------------
 -- 11. callerPackageRoot end-to-end: when invoked from inside this test

--- a/src/tasty-streaming/test/Convex/Tasty/SrcLocSpec.hs
+++ b/src/tasty-streaming/test/Convex/Tasty/SrcLocSpec.hs
@@ -12,6 +12,13 @@ module Convex.Tasty.SrcLocSpec (tests) where
 import Convex.Tasty.HUnit (Assertion, assertBool, assertEqual, assertFailure, testCase, (@?=))
 import Convex.Tasty.HUnit qualified as ConvexHU
 import Convex.Tasty.QuickCheck qualified as ConvexQC
+import Convex.Tasty.Streaming.QCStats (
+  QCStatsRecorder (..),
+  lookupQCStatsByTestInfo,
+  mkQCStatsKey,
+  newQCStatsStore,
+  storeQCStatsRecorder,
+ )
 import Convex.Tasty.Streaming.SrcLoc (
   SrcLocRange (..),
   callerPackageRoot,
@@ -19,7 +26,7 @@ import Convex.Tasty.Streaming.SrcLoc (
   withSrcLoc,
  )
 import Convex.Tasty.Streaming.TreeMap (buildTestMap)
-import Convex.Tasty.Streaming.Types (Event (..), TestInfo (..))
+import Convex.Tasty.Streaming.Types (Event (..), MonitoringStats (..), TestInfo (..), TestOutcome (..))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.KeyMap qualified as KeyMap
 import Data.IntMap.Strict qualified as IntMap
@@ -43,6 +50,12 @@ tests =
     , testCase "round-trip without srcLoc (key absent)" roundTripWithoutSrcLoc
     , testCase "SuiteStarted round-trip with packageRoot" suiteStartedWithPackageRoot
     , testCase "SuiteStarted without packageRoot (key absent)" suiteStartedWithoutPackageRoot
+    , testCase "TestDone without monitoring_stats omits key" testDoneWithoutMonitoringOmitKey
+    , testCase "TestDone with monitoring_stats includes key" testDoneWithMonitoringIncludesKey
+    , testCase "MonitoringStats round-trip" monitoringStatsRoundTrip
+    , testCase "TestDone round-trip with monitoring_stats" testDoneRoundTripWithMonitoring
+    , testCase "QC stats key differs across test identities" qcStatsKeyDiffersAcrossTestIdentities
+    , testCase "QC stats lookup uses TestInfo fallback" qcStatsLookupUsesTestInfoFallback
     , testCase "callerPackageRoot resolves to convex-tasty-streaming" callerPackageRootResolvesToThisPackage
     , testCase "findPackageRootFromFile finds convex-tasty-streaming" findPackageRootFromFileFindsThisPackage
     ]
@@ -270,7 +283,150 @@ suiteStartedWithoutPackageRoot = do
     Right evt' -> evt' @?= evt
 
 -- ---------------------------------------------------------------------------
--- 9. callerPackageRoot end-to-end: when invoked from inside this test
+-- 9. TestDone monitoring JSON coverage
+-- ---------------------------------------------------------------------------
+
+testDoneWithoutMonitoringOmitKey :: Assertion
+testDoneWithoutMonitoringOmitKey = do
+  let evt =
+        TestDone
+          { edId = 11
+          , edOutcome = TestSuccess
+          , edDuration = 0.5
+          , edDescription = "done"
+          , edThreatModel = Nothing
+          , edMonitoringStats = Nothing
+          }
+      encoded = Aeson.encode evt
+  case Aeson.decode encoded :: Maybe Aeson.Value of
+    Just (Aeson.Object o) ->
+      assertBool
+        "Encoded TestDone must omit monitoring_stats when edMonitoringStats is Nothing"
+        (not (KeyMap.member "monitoring_stats" o))
+    other ->
+      assertFailure $ "Expected JSON object, got: " <> show other
+
+testDoneWithMonitoringIncludesKey :: Assertion
+testDoneWithMonitoringIncludesKey = do
+  let stats =
+        MonitoringStats
+          { msNumTests = 10
+          , msNumDiscarded = 2
+          , msLabels = []
+          , msClasses = []
+          , msTables = []
+          }
+      evt =
+        TestDone
+          { edId = 12
+          , edOutcome = TestSuccess
+          , edDuration = 0.7
+          , edDescription = "done"
+          , edThreatModel = Nothing
+          , edMonitoringStats = Just stats
+          }
+      encoded = Aeson.encode evt
+  case Aeson.decode encoded :: Maybe Aeson.Value of
+    Just (Aeson.Object o) ->
+      assertBool
+        "Encoded TestDone must include monitoring_stats when edMonitoringStats is Just"
+        (KeyMap.member "monitoring_stats" o)
+    other ->
+      assertFailure $ "Expected JSON object, got: " <> show other
+
+monitoringStatsRoundTrip :: Assertion
+monitoringStatsRoundTrip = do
+  let stats =
+        MonitoringStats
+          { msNumTests = 42
+          , msNumDiscarded = 3
+          , msLabels = []
+          , msClasses = []
+          , msTables = []
+          }
+      encoded = Aeson.encode stats
+  case Aeson.eitherDecode encoded of
+    Left err -> assertFailure $ "decode failed: " <> err
+    Right stats' -> stats' @?= stats
+
+testDoneRoundTripWithMonitoring :: Assertion
+testDoneRoundTripWithMonitoring = do
+  let stats =
+        MonitoringStats
+          { msNumTests = 99
+          , msNumDiscarded = 4
+          , msLabels = []
+          , msClasses = []
+          , msTables = []
+          }
+      evt =
+        TestDone
+          { edId = 13
+          , edOutcome = TestSuccess
+          , edDuration = 1.3
+          , edDescription = "done with stats"
+          , edThreatModel = Nothing
+          , edMonitoringStats = Just stats
+          }
+      encoded = Aeson.encode evt
+  case Aeson.eitherDecode encoded of
+    Left err -> assertFailure $ "decode failed: " <> err
+    Right evt' -> evt' @?= evt
+
+-- ---------------------------------------------------------------------------
+-- 10. QC stats keying and lookup behavior
+-- ---------------------------------------------------------------------------
+
+qcStatsKeyDiffersAcrossTestIdentities :: Assertion
+qcStatsKeyDiffersAcrossTestIdentities = do
+  let loc =
+        SrcLocRange
+          { slrFile = "src/Foo.hs"
+          , slrStartLine = 10
+          , slrStartCol = 5
+          , slrEndLine = 10
+          , slrEndCol = 13
+          }
+      keyA = mkQCStatsKey loc ["group-a"] "leaf"
+      keyB = mkQCStatsKey loc ["group-b"] "leaf"
+      keyC = mkQCStatsKey loc [] "leaf-2"
+  assertBool "Different groups must produce different keys" (keyA /= keyB)
+  assertBool "Different test names must produce different keys" (keyA /= keyC)
+
+qcStatsLookupUsesTestInfoFallback :: Assertion
+qcStatsLookupUsesTestInfoFallback = do
+  store <- newQCStatsStore
+  let recorder = storeQCStatsRecorder store
+      loc =
+        SrcLocRange
+          { slrFile = "src/Foo.hs"
+          , slrStartLine = 10
+          , slrStartCol = 5
+          , slrEndLine = 10
+          , slrEndCol = 13
+          }
+      stats =
+        MonitoringStats
+          { msNumTests = 42
+          , msNumDiscarded = 1
+          , msLabels = []
+          , msClasses = []
+          , msTables = []
+          }
+      ti =
+        TestInfo
+          { tiId = 7
+          , tiName = "leaf"
+          , tiPath = ["group"]
+          , tiSrcLoc = Just loc
+          }
+  -- Simulate recorder-side write when only test name is available.
+  qcRecordStats recorder (mkQCStatsKey loc [] "leaf") stats
+  mFound <- lookupQCStatsByTestInfo store ti
+  assertEqual "lookup should find stats via name-only fallback" (Just stats) mFound
+
+-- ---------------------------------------------------------------------------
+-- 11. callerPackageRoot end-to-end: when invoked from inside this test
 --    suite, it must resolve to the package directory containing the
 --    convex-tasty-streaming.cabal file (this same package).
 -- ---------------------------------------------------------------------------
@@ -296,7 +452,7 @@ callerPackageRootResolvesToThisPackage = do
         ("src/tasty-streaming" `isSuffixOf` root)
 
 -- ---------------------------------------------------------------------------
--- 10. findPackageRootFromFile end-to-end: given a known package-relative
+-- 12. findPackageRootFromFile end-to-end: given a known package-relative
 --     path to a file inside convex-tasty-streaming, the helper must return
 --     the package directory.
 -- ---------------------------------------------------------------------------

--- a/src/testing-interface/convex-testing-interface.cabal
+++ b/src/testing-interface/convex-testing-interface.cabal
@@ -93,7 +93,6 @@ library
     , tasty
     , tasty-expected-failure
     , tasty-hunit
-    , tasty-quickcheck
     , text
     , time
 
@@ -180,3 +179,4 @@ test-suite convex-testing-interface-test
     , tasty-expected-failure
     , tasty-hunit
     , tasty-quickcheck
+    , text

--- a/src/testing-interface/lib/Convex/TestingInterface.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface.hs
@@ -65,13 +65,13 @@ module Convex.TestingInterface (
 
 import Control.Monad (forM, unless, when)
 import Control.Monad.IO.Class (MonadIO, liftIO)
+import Convex.Tasty.QuickCheck (testProperty)
 import Test.HUnit (Assertion)
 import Test.QuickCheck (Arbitrary (..), Gen, Property, counterexample, discard, elements, frequency, oneof, property)
 import Test.QuickCheck.Monadic (PropertyM, monadicIO, monitor, pick, run)
 import Test.Tasty (DependencyType (..), TestTree, askOption, sequentialTestGroup, testGroup, withResource)
 import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import Test.Tasty.HUnit (assertFailure, testCaseSteps)
-import Test.Tasty.QuickCheck (testProperty)
 
 import Cardano.Api qualified as C
 import Cardano.Ledger.Core qualified as L


### PR DESCRIPTION
This pull request introduces QuickCheck monitoring statistics into the streaming test reporting infrastructure. It adds new types to represent monitoring data, collects and stores these statistics during test execution, and emits them as part of the streaming JSON output. The changes span the addition of new types, integration in the QuickCheck test runner, and extension of the streaming reporter and schema.

**QuickCheck monitoring statistics integration:**

* Added new types for monitoring statistics (`MonitoringStats`, `MonitoringLabelStat`, `MonitoringClassStat`, `MonitoringTableStat`, `MonitoringTableEntry`) to `Convex.Tasty.Streaming.Types`, along with their JSON and OpenAPI schema instances. [[1]](diffhunk://#diff-22c76e3b71452975887c838b5415d568b116cf474fb18d419bdbc7b010f906b3R75-R184) [[2]](diffhunk://#diff-98492209d24b85687062e4f482bfcef71b0f32bad170328a23195b9df683ddb3R157-R236)
* Implemented the `Convex.Tasty.Streaming.QCStats` module, which provides a store for monitoring stats, a recorder, and functions to extract and record stats from QuickCheck state.
* Modified `testProperty` in `Convex.Tasty.QuickCheck` to record monitoring statistics after each test, using the new recorder and store, and updated the test runner to pass these options. [[1]](diffhunk://#diff-21a8bd61a63ede6b129404b01072df909177d36048d93e8c54ac59aea85ae0a9L24-R28) [[2]](diffhunk://#diff-21a8bd61a63ede6b129404b01072df909177d36048d93e8c54ac59aea85ae0a9L35-R48)

**Streaming reporter and event changes:**

* Updated the streaming reporter in `Convex.Tasty.Streaming` to initialize and pass the monitoring stats store and recorder, look up stats after each test, and include them in the emitted `test_done` event. [[1]](diffhunk://#diff-4a30c577e4b5c71893042c0d996ff4ba6114347cf065a403ff78ecf6e01db208R12-R18) [[2]](diffhunk://#diff-4a30c577e4b5c71893042c0d996ff4ba6114347cf065a403ff78ecf6e01db208R130-R131) [[3]](diffhunk://#diff-4a30c577e4b5c71893042c0d996ff4ba6114347cf065a403ff78ecf6e01db208R146) [[4]](diffhunk://#diff-4a30c577e4b5c71893042c0d996ff4ba6114347cf065a403ff78ecf6e01db208R240-R242) [[5]](diffhunk://#diff-4a30c577e4b5c71893042c0d996ff4ba6114347cf065a403ff78ecf6e01db208R260) [[6]](diffhunk://#diff-4a30c577e4b5c71893042c0d996ff4ba6114347cf065a403ff78ecf6e01db208R383) [[7]](diffhunk://#diff-4a30c577e4b5c71893042c0d996ff4ba6114347cf065a403ff78ecf6e01db208R415-R416)
* Extended the `Event` type and its JSON encoding to include an optional `monitoring_stats` field in the `test_done` event, and updated the OpenAPI schema accordingly. [[1]](diffhunk://#diff-22c76e3b71452975887c838b5415d568b116cf474fb18d419bdbc7b010f906b3R210) [[2]](diffhunk://#diff-22c76e3b71452975887c838b5415d568b116cf474fb18d419bdbc7b010f906b3L127-R243) [[3]](diffhunk://#diff-22c76e3b71452975887c838b5415d568b116cf474fb18d419bdbc7b010f906b3R252) [[4]](diffhunk://#diff-22c76e3b71452975887c838b5415d568b116cf474fb18d419bdbc7b010f906b3R261-R262) [[5]](diffhunk://#diff-98492209d24b85687062e4f482bfcef71b0f32bad170328a23195b9df683ddb3R286)

**Cabal and dependency updates:**

* Registered the new `Convex.Tasty.Streaming.QCStats` module and added `QuickCheck` as a library dependency in the Cabal file. [[1]](diffhunk://#diff-aef4084fccdffd02a12aaf4aba1ef44f65ccb4b33ce2e872058500f4bc955f23R44) [[2]](diffhunk://#diff-aef4084fccdffd02a12aaf4aba1ef44f65ccb4b33ce2e872058500f4bc955f23R59)

**Schema and import updates:**

* Updated imports and OpenAPI schema generation to reflect the new monitoring statistics types. [[1]](diffhunk://#diff-98492209d24b85687062e4f482bfcef71b0f32bad170328a23195b9df683ddb3L24-R34) [[2]](diffhunk://#diff-98492209d24b85687062e4f482bfcef71b0f32bad170328a23195b9df683ddb3R157-R236)

These changes enable richer reporting of QuickCheck test monitoring data, which can be consumed downstream for analysis and visualization.