### PR TITLE
Update way to specify nullable in json schema

### DIFF
--- a/src/schema-gen/lib/Convex/SchemaGen.hs
+++ b/src/schema-gen/lib/Convex/SchemaGen.hs
@@ -6,7 +6,7 @@ module Convex.SchemaGen (
   streamingEventSchema,
 ) where
 
-import Control.Lens hiding (allOf, (.=))
+import Control.Lens hiding (anyOf, (.=))
 import Data.Aeson ((.=))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Key
@@ -18,6 +18,7 @@ import Data.OpenApi.Lens qualified as L
 import Data.Proxy (Proxy (..))
 import Data.Text (Text)
 import Data.Text qualified as Text
+import Prelude hiding (null)
 
 -- Types from convex-tasty-streaming
 import Convex.Tasty.Streaming.SrcLoc (SrcLocRanges (..))
@@ -89,6 +90,19 @@ fixRefs (Aeson.Object o) = Aeson.Object $
       _ -> o
 fixRefs (Aeson.Array a) = Aeson.Array $ fmap fixRefs a
 fixRefs v = v
+
+-- | Modern way of specifying nullable types in OpenAPI 3.1: use anyOf with the type and null.
+nullableType :: OpenApiType -> Referenced Schema
+nullableType t =
+  Inline $
+    mempty
+      & anyOf
+        ?~ [ Inline $ mempty & type_ ?~ t
+           , null
+           ]
+
+null :: Referenced Schema
+null = Inline $ mempty & enum_ ?~ [Aeson.Null]
 
 -- ============================================================
 -- ToSchema instances for convex-tasty-streaming types
@@ -383,10 +397,10 @@ instance ToSchema TxInputSummary where
               [ ("utxo", Inline $ mempty & type_ ?~ OpenApiString)
               , ("address", Inline $ mempty & type_ ?~ OpenApiString)
               , ("value", valueRef)
-              , ("redeemerRaw", Inline $ mempty & type_ ?~ OpenApiString & nullable ?~ True)
-              , ("redeemerConstr", Inline $ mempty & type_ ?~ OpenApiInteger & nullable ?~ True)
-              , ("redeemerKind", Inline $ mempty & type_ ?~ OpenApiString & nullable ?~ True)
-              , ("redeemerPayload", Inline $ mempty & nullable ?~ True)
+              , ("redeemerRaw", nullableType OpenApiString)
+              , ("redeemerConstr", nullableType OpenApiInteger)
+              , ("redeemerKind", nullableType OpenApiString)
+              , ("redeemerPayload", Inline mempty)
               ]
           & required .~ ["utxo", "address", "value", "redeemerRaw", "redeemerConstr", "redeemerKind", "redeemerPayload"]
 
@@ -402,7 +416,7 @@ instance ToSchema TxOutputSummary where
               [ ("utxo", Inline $ mempty & type_ ?~ OpenApiString)
               , ("address", Inline $ mempty & type_ ?~ OpenApiString)
               , ("value", valueRef)
-              , ("datum", Inline $ mempty & type_ ?~ OpenApiString & nullable ?~ True) -- key present, value null when no datum
+              , ("datum", nullableType OpenApiString) -- key present, value null when no datum
               ]
           & required .~ ["utxo", "address", "value", "datum"]
 
@@ -417,13 +431,13 @@ instance ToSchema TxSummary where
           & type_ ?~ OpenApiObject
           & properties
             .~ InsOrdHashMap.fromList
-              [ ("id", Inline $ mempty & type_ ?~ OpenApiString & nullable ?~ True)
+              [ ("id", nullableType OpenApiString)
               , ("inputs", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject inputRef)
               , ("outputs", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject outputRef)
-              , ("mint", Inline $ mempty & nullable ?~ True & allOf ?~ [valueRef]) -- nullable ref
+              , ("mint", Inline $ mempty & anyOf ?~ [valueRef, null]) -- nullable ref
               , ("fee", Inline $ mempty & type_ ?~ OpenApiInteger)
-              , ("signers", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject (Inline $ mempty & type_ ?~ OpenApiString))
-              , ("validRange", Inline $ mempty & type_ ?~ OpenApiString & nullable ?~ True)
+              , ("signers", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject (nullableType OpenApiString))
+              , ("validRange", nullableType OpenApiString)
               ]
           & required .~ ["id", "inputs", "outputs", "mint", "fee", "signers", "validRange"]
 
@@ -467,7 +481,7 @@ instance ToSchema Transition where
               , ("action", Inline $ mempty & type_ ?~ OpenApiString)
               , ("stateBefore", Inline mempty) -- opaque JSON (user model state)
               , ("stateAfter", Inline mempty) -- opaque JSON (user model state)
-              , ("transaction", Inline $ mempty & nullable ?~ True & allOf ?~ [txRef]) -- nullable ref
+              , ("transaction", Inline $ mempty & anyOf ?~ [txRef, null]) -- nullable ref
               , ("result", resultRef)
               ]
           & required .~ ["stepIndex", "action", "stateBefore", "stateAfter", "transaction", "result"]
@@ -550,8 +564,8 @@ instance ToSchema ThreatModelTraceOutcome where
 instance ToSchema TxMod where
   declareNamedSchema _ = do
     valueRef <- declareSchemaRef (Proxy @ValueSummary)
-    let nullableString = Inline $ mempty & type_ ?~ OpenApiString & nullable ?~ True
-    let nullableValue = Inline $ mempty & nullable ?~ True & allOf ?~ [valueRef]
+    let nullableString = nullableType OpenApiString
+    let nullableValue = Inline $ mempty & anyOf ?~ [valueRef, null]
 
     let removeInput =
           mempty
@@ -774,7 +788,7 @@ instance ToSchema ThreatModelTrace where
               , ("targetTxIndex", Inline $ mempty & type_ ?~ OpenApiInteger)
               , ("modifications", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject txModRef)
               , ("originalTx", txRef)
-              , ("modifiedTx", Inline $ mempty & nullable ?~ True & allOf ?~ [txRef])
+              , ("modifiedTx", Inline $ mempty & anyOf ?~ [txRef, null])
               , ("outcome", outcomeRef)
               , ("covered", Inline $ mempty & type_ ?~ OpenApiArray & items ?~ OpenApiItemsObject srcLocRanges)
               ]

--- a/src/tasty-streaming/schema/streaming-events.schema.json
+++ b/src/tasty-streaming/schema/streaming-events.schema.json
@@ -555,12 +555,16 @@
                     "type": "array"
                 },
                 "modifiedTx": {
-                    "allOf": [
+                    "anyOf": [
                         {
                             "$ref": "#/$defs/TxSummary"
+                        },
+                        {
+                            "enum": [
+                                null
+                            ]
                         }
-                    ],
-                    "nullable": true
+                    ]
                 },
                 "name": {
                     "type": "string"
@@ -680,12 +684,16 @@
                     "type": "integer"
                 },
                 "transaction": {
-                    "allOf": [
+                    "anyOf": [
                         {
                             "$ref": "#/$defs/TxSummary"
+                        },
+                        {
+                            "enum": [
+                                null
+                            ]
                         }
-                    ],
-                    "nullable": true
+                    ]
                 }
             },
             "required": [
@@ -749,19 +757,41 @@
                     "type": "string"
                 },
                 "redeemerConstr": {
-                    "nullable": true,
-                    "type": "integer"
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "enum": [
+                                null
+                            ]
+                        }
+                    ]
                 },
                 "redeemerKind": {
-                    "nullable": true,
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "enum": [
+                                null
+                            ]
+                        }
+                    ]
                 },
-                "redeemerPayload": {
-                    "nullable": true
-                },
+                "redeemerPayload": {},
                 "redeemerRaw": {
-                    "nullable": true,
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "enum": [
+                                null
+                            ]
+                        }
+                    ]
                 },
                 "utxo": {
                     "type": "string"
@@ -826,19 +856,43 @@
                 {
                     "properties": {
                         "address": {
-                            "nullable": true,
-                            "type": "string"
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
+                                }
+                            ]
                         },
                         "datum": {
-                            "nullable": true,
-                            "type": "string"
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
+                                }
+                            ]
                         },
                         "index": {
                             "type": "integer"
                         },
                         "referenceScript": {
-                            "nullable": true,
-                            "type": "string"
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
+                                }
+                            ]
                         },
                         "type": {
                             "enum": [
@@ -847,12 +901,16 @@
                             "type": "string"
                         },
                         "value": {
-                            "allOf": [
+                            "anyOf": [
                                 {
                                     "$ref": "#/$defs/ValueSummary"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
                                 }
-                            ],
-                            "nullable": true
+                            ]
                         }
                     },
                     "required": [
@@ -868,16 +926,40 @@
                 {
                     "properties": {
                         "address": {
-                            "nullable": true,
-                            "type": "string"
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
+                                }
+                            ]
                         },
                         "datum": {
-                            "nullable": true,
-                            "type": "string"
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
+                                }
+                            ]
                         },
                         "referenceScript": {
-                            "nullable": true,
-                            "type": "string"
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
+                                }
+                            ]
                         },
                         "type": {
                             "enum": [
@@ -889,12 +971,16 @@
                             "type": "string"
                         },
                         "value": {
-                            "allOf": [
+                            "anyOf": [
                                 {
                                     "$ref": "#/$defs/ValueSummary"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
                                 }
-                            ],
-                            "nullable": true
+                            ]
                         }
                     },
                     "required": [
@@ -910,16 +996,40 @@
                 {
                     "properties": {
                         "datum": {
-                            "nullable": true,
-                            "type": "string"
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
+                                }
+                            ]
                         },
                         "redeemer": {
-                            "nullable": true,
-                            "type": "string"
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
+                                }
+                            ]
                         },
                         "referenceScript": {
-                            "nullable": true,
-                            "type": "string"
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
+                                }
+                            ]
                         },
                         "type": {
                             "enum": [
@@ -931,12 +1041,16 @@
                             "type": "string"
                         },
                         "value": {
-                            "allOf": [
+                            "anyOf": [
                                 {
                                     "$ref": "#/$defs/ValueSummary"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
                                 }
-                            ],
-                            "nullable": true
+                            ]
                         }
                     },
                     "required": [
@@ -952,8 +1066,16 @@
                 {
                     "properties": {
                         "lowerBound": {
-                            "nullable": true,
-                            "type": "string"
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
+                                }
+                            ]
                         },
                         "type": {
                             "enum": [
@@ -962,8 +1084,16 @@
                             "type": "string"
                         },
                         "upperBound": {
-                            "nullable": true,
-                            "type": "string"
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
+                                }
+                            ]
                         }
                     },
                     "required": [
@@ -979,8 +1109,16 @@
                             "type": "string"
                         },
                         "datum": {
-                            "nullable": true,
-                            "type": "string"
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
+                                }
+                            ]
                         },
                         "referenceScript": {
                             "type": "string"
@@ -1010,8 +1148,16 @@
                             "type": "string"
                         },
                         "datum": {
-                            "nullable": true,
-                            "type": "string"
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
+                                }
+                            ]
                         },
                         "isReferenceInput": {
                             "type": "boolean"
@@ -1042,8 +1188,16 @@
                 {
                     "properties": {
                         "datum": {
-                            "nullable": true,
-                            "type": "string"
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
+                                }
+                            ]
                         },
                         "redeemer": {
                             "type": "string"
@@ -1073,8 +1227,16 @@
                 {
                     "properties": {
                         "datum": {
-                            "nullable": true,
-                            "type": "string"
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
+                                }
+                            ]
                         },
                         "redeemer": {
                             "type": "string"
@@ -1104,8 +1266,16 @@
                 {
                     "properties": {
                         "datum": {
-                            "nullable": true,
-                            "type": "string"
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "enum": [
+                                        null
+                                    ]
+                                }
+                            ]
                         },
                         "referenceScript": {
                             "type": "string"
@@ -1220,8 +1390,16 @@
                     "type": "string"
                 },
                 "datum": {
-                    "nullable": true,
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "enum": [
+                                null
+                            ]
+                        }
+                    ]
                 },
                 "utxo": {
                     "type": "string"
@@ -1244,8 +1422,16 @@
                     "type": "integer"
                 },
                 "id": {
-                    "nullable": true,
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "enum": [
+                                null
+                            ]
+                        }
+                    ]
                 },
                 "inputs": {
                     "items": {
@@ -1254,12 +1440,16 @@
                     "type": "array"
                 },
                 "mint": {
-                    "allOf": [
+                    "anyOf": [
                         {
                             "$ref": "#/$defs/ValueSummary"
+                        },
+                        {
+                            "enum": [
+                                null
+                            ]
                         }
-                    ],
-                    "nullable": true
+                    ]
                 },
                 "outputs": {
                     "items": {
@@ -1269,13 +1459,30 @@
                 },
                 "signers": {
                     "items": {
-                        "type": "string"
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "enum": [
+                                    null
+                                ]
+                            }
+                        ]
                     },
                     "type": "array"
                 },
                 "validRange": {
-                    "nullable": true,
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "enum": [
+                                null
+                            ]
+                        }
+                    ]
                 }
             },
             "required": [


### PR DESCRIPTION
The json schema validator `ajv` that we use in the extension removed support for `nullable`.