### PR TITLE
randomise  threat models parameters

### DIFF
--- a/docs/skill/skill-v1/references/03-testing-interface-class.md
+++ b/docs/skill/skill-v1/references/03-testing-interface-class.md
@@ -212,6 +212,8 @@ Empty `threatModels` disables threat-model evaluation entirely; only
 positive and negative tests run. Pick models from
 `06-threat-models.md` once the suite is green.
 
+Parameterised threat models (`largeDataAttack`, `largeValueAttack`, etc.) now follow a three-tier convention (`model` / `modelWith` / `modelWithGen`). The no-suffix form randomises parameters per transaction. See `06-threat-models.md §G` for the full convention.
+
 ## J. `TestingMonadT`
 
 ```haskell

--- a/docs/skill/skill-v1/references/06-threat-models.md
+++ b/docs/skill/skill-v1/references/06-threat-models.md
@@ -93,8 +93,11 @@ diagnostic.
 as non-parameterised `ThreatModel ()` values. Several have
 parameterised `…With` siblings exposed by individual modules.
 `tokenForgeryAttack` is NOT in `allThreatModels` (it needs a
-minting-policy argument). Total: 18 default + 8 parameterised = 26
-callable forms.
+minting-policy argument). Six of the parameterised models also offer
+a `…WithGen` variant. Total: 18 default + 8 parameterised + 6
+generator = 32 callable forms.
+
+Parameterised models follow a three-tier convention: `model` (randomised default), `modelWith` (fixed value), and `modelWithGen` (explicit generator). See §G.
 
 ### B.1 Output redirection
 
@@ -109,8 +112,8 @@ callable forms.
 | name | description | applies when |
 |---|---|---|
 | `tokenForgeryAttack` / `tokenForgeryAttackWith :: ScriptData -> PlutusScript lang -> AssetName -> ThreatModel ()` | Mints additional tokens under a supplied policy and adds them to a key-address output. | Contract has (or could be paired with) a minting policy. **Not** in `allThreatModels`. |
-| `largeValueAttack` / `largeValueAttackWith :: Int -> ThreatModel ()` | Mints N unique junk tokens (default 50) using an always-succeeds policy and stuffs them into a script output. | Tx has at least one script output. |
-| `valueUnderpaymentAttack` / `valueUnderpaymentAttackWith :: Double -> ThreatModel ()` | Reduces ADA on a script output by the given factor (default 0.5). | Tx has a script output carrying more than ~2 ADA. |
+| `largeValueAttack` / `largeValueAttackWith :: Int -> ThreatModel ()` / `largeValueAttackWithGen :: Gen Int -> ThreatModel ()` | Mints N unique junk tokens (default 50) using an always-succeeds policy and stuffs them into a script output. | Tx has at least one script output. |
+| `valueUnderpaymentAttack` / `valueUnderpaymentAttackWith :: Double -> ThreatModel ()` / `valueUnderpaymentAttackWithGen :: Gen Double -> ThreatModel ()` | Reduces ADA on a script output by the given factor (default 0.5). | Tx has a script output carrying more than ~2 ADA. |
 | `redeemerAssetSubstitution` | Substitutes asset identifiers referenced in redeemers. | Contract uses redeemers that name assets/policies. |
 
 ### B.3 Authorization bypass
@@ -124,12 +127,12 @@ callable forms.
 
 | name | description | applies when |
 |---|---|---|
-| `largeDataAttack` / `largeDataAttackWith :: Int -> ThreatModel ()` | Appends N extra fields (default 1000) of `ScriptDataNumber 42` to an inline-datum constructor. | Script input + script output with inline datum whose top-level shape is `ScriptDataConstructor`. |
-| `datumByteBloatAttack` / `datumByteBloatAttackWith :: Int -> ThreatModel ()` | Inflates the first list-item bytestring inside a datum to N bytes (default 10 000). | Inline datum contains a non-empty list whose first item is a ByteString-like value. |
-| `datumListBloatAttack` / `datumListBloatAttackWith :: Int -> Int -> ThreatModel ()` | Appends N items of M bytes to every list field in an inline datum (defaults 5 × 100). | Inline datum contains at least one list field. |
+| `largeDataAttack` / `largeDataAttackWith :: Int -> ThreatModel ()` / `largeDataAttackWithGen :: Gen Int -> ThreatModel ()` | Appends N extra fields (default 1000) of `ScriptDataNumber 42` to an inline-datum constructor. | Script input + script output with inline datum whose top-level shape is `ScriptDataConstructor`. |
+| `datumByteBloatAttack` / `datumByteBloatAttackWith :: Int -> ThreatModel ()` / `datumByteBloatAttackWithGen :: Gen Int -> ThreatModel ()` | Inflates the first list-item bytestring inside a datum to N bytes (default 10 000). | Inline datum contains a non-empty list whose first item is a ByteString-like value. |
+| `datumListBloatAttack` / `datumListBloatAttackWith :: Int -> Int -> ThreatModel ()` / `datumListBloatAttackWithGen :: Gen (Int, Int) -> ThreatModel ()` | Appends N items of M bytes to every list field in an inline datum (defaults 5 × 100). | Inline datum contains at least one list field. |
 | `duplicateListEntryAttack` | Duplicates the first entry of every non-empty list field. | Inline datum contains a non-empty list. |
 | `negativeIntegerAttack` | Replaces integer fields with negative values. | Datum or redeemer carries integer fields where sign matters. |
-| `invalidDatumIndexAttack` | Targets datum-lookup-by-index patterns with out-of-range indices. | Validator selects datum entries by index. |
+| `invalidDatumIndexAttack` / `invalidDatumIndexAttackWith :: Int -> ThreatModel ()` / `invalidDatumIndexAttackWithGen :: Gen Int -> ThreatModel ()` | Targets datum-lookup-by-index patterns with out-of-range indices. | Validator selects datum entries by index. |
 | `missingOutputDatumAttack` | Omits a required output datum. | Script outputs carry datums the validator expects. |
 | `outputDatumHashMissingAttack` | Omits the datum hash on an output. | Script outputs use datum-hash references. |
 
@@ -186,6 +189,8 @@ length checks.
   uniqueness (e.g. uses a set abstraction).
 - `largeValueAttackWith N` — skip if output value structure is
   whitelisted.
+
+**Note:** The no-suffix forms (`largeDataAttack`, `largeValueAttack`, etc.) now randomise their parameters per transaction by default. Use the `…With` form for deterministic regression tests, or `…WithGen` for a custom range. The parameter distribution is visible in QuickCheck output via `tabulate`.
 
 ### Default-on for any contract handling Ada / native-token outputs
 
@@ -256,14 +261,16 @@ import Convex.ThreatModel                          (ThreatModel)
 import Convex.ThreatModel.UnprotectedScriptOutput  (unprotectedScriptOutput)
 import Convex.ThreatModel.DoubleSatisfaction       (doubleSatisfaction)
 import Convex.ThreatModel.SignatoryRemoval         (signatoryRemoval)
-import Convex.ThreatModel.LargeData                (largeDataAttackWith)
+import Convex.ThreatModel.LargeData      (largeDataAttack)  -- randomised default
+-- or: (largeDataAttackWith)             -- for fixed value
+-- or: (largeDataAttackWithGen)          -- for custom Gen range
 
 instance ThreatModelsFor MyModel where
   threatModels =
     [ unprotectedScriptOutput
     , doubleSatisfaction
     , signatoryRemoval
-    , largeDataAttackWith 10
+    , largeDataAttack  -- randomised; was largeDataAttackWith 10
     ]
   expectedVulnerabilities = []
 ```
@@ -322,3 +329,57 @@ pattern, point them at the `ThreatModel` monad and its combinators
 `shouldNotValidate`, `Named`, plus `TxModifier` `Monoid` composition
 with `<>`). Documented under "Writing Custom Threat Models" in the
 [main README](https://github.com/input-output-hk/sc-testing-tools/blob/main/README.md).
+
+## §G. Parameterised threat models — the three-tier convention
+
+Every parameterised built-in follows a consistent three-tier API:
+
+| Tier | Signature shape | When to use |
+|---|---|---|
+| `model` | `ThreatModel ()` | Default. Parameter randomised per transaction via a curated `Gen`. Goes in `allThreatModels`. |
+| `modelWith` | `ParamType -> ThreatModel ()` | Fixed value. Deterministic regression tests, golden seeds, CI reproducibility. |
+| `modelWithGen` | `Gen ParamType -> ThreatModel ()` | Explicit generator. Power users with domain knowledge about the interesting range. |
+
+### How randomisation works
+
+The parameter is drawn fresh for each transaction in each QuickCheck iteration via `forAllTM` (the `ThreatModel` DSL's embedding of QuickCheck generation). This means:
+
+- QuickCheck explores the parameter space across iterations.
+- The parameter distribution is reported via `tabulate` (visible in test output).
+- Vacuous draws (e.g. a field count of 0 for large-data) are skipped via `ensure`, so a `TMPassed` outcome always means a meaningful attack was attempted and rejected.
+- In the pure `runThreatModel` runner, the parameter is shrunk toward the smallest triggering value, giving minimal counterexamples.
+
+### When to use which tier
+
+- **`model`** (randomised): the right default for `threatModels` lists. Zero configuration; QuickCheck finds the interesting region.
+- **`modelWith N`**: when you need determinism — regression tests against a known seed, golden tests, CI reproducibility.
+- **`modelWithGen gen`**: when you have domain knowledge. E.g. `largeDataAttackWithGen (choose (50, 200))` if you know your validator only becomes interesting above 50 fields.
+
+### Writing parameterised custom models
+
+If your custom threat model has a numeric strength parameter, follow the same convention:
+
+1. Write `modelWithGen :: Gen N -> ThreatModel ()` as the primitive.
+2. Specialise: `modelWith n = modelWithGen (pure n)` and `model = modelWithGen (choose (lo, hi))`.
+3. `tabulateTM` the parameter so users see the distribution.
+4. `ensure` a meaningful lower bound so vacuous draws are skipped.
+5. Provide a shrinker that shrinks toward the smallest meaningful value.
+
+Example (from `Convex.ThreatModel.LargeData`):
+
+```haskell
+largeDataAttackWithGen :: Gen Int -> ThreatModel ()
+largeDataAttackWithGen fieldsGen =
+    Named "Large Data Attack" $ do
+      n <- forAllTM fieldsGen shrinkPositive
+      ensure (n >= 1)
+      ...                         -- attack body, parameterised on n
+      tabulateTM "fields injected" [bucket n]
+      shouldNotValidate $ ...     -- the TxModifier
+
+largeDataAttackWith :: Int -> ThreatModel ()
+largeDataAttackWith = largeDataAttackWithGen . pure
+
+largeDataAttack :: ThreatModel ()
+largeDataAttack = largeDataAttackWithGen (choose (1, 1000))
+```

--- a/src/testing-interface/lib/Convex/TestingInterface.hs
+++ b/src/testing-interface/lib/Convex/TestingInterface.hs
@@ -658,9 +658,9 @@ positiveTestTraced opts groupName mGetTmResultsRef tms evs recorder iterIdx = do
         allToRun = tmsToRun <> evs
     tmResultsWithCov <- liftIO $ forM allToRun $ \tm -> do
       let name = fromMaybe "Unnamed" (getThreatModelName tm)
-      ((outcome, traceEntries), tmFinalState) <-
+      ((outcome, traceEntries, monitors), tmFinalState) <-
         runMockchainIO (runThreatModelCheckTraced AutoSign tm envs) params state0
-      pure (name, outcome, traceEntries, mcsCoverageData tmFinalState)
+      pure (name, outcome, traceEntries, mcsCoverageData tmFinalState, monitors)
 
     pure (finalState, transitions, tmResultsWithCov)
 
@@ -678,12 +678,12 @@ positiveTestTraced opts groupName mGetTmResultsRef tms evs recorder iterIdx = do
       run $ recordIteration recorder groupName "positive" (covDataToSrcLocRanges covData) (toJSON trace)
       pure (property False)
     (Right (finalState, transitions, tmResultsWithCov), MockChainState{mcsCoverageData}) -> do
-      let covData = mcsCoverageData <> mconcat [cov | (_, _, _, cov) <- tmResultsWithCov]
+      let covData = mcsCoverageData <> mconcat [cov | (_, _, _, cov, _) <- tmResultsWithCov]
       monitor (counterexample $ "Final state: " ++ show finalState)
       traverse_ (\ref -> liftIO $ modifyIORef ref (<> covData)) coverageRef
       case mGetTmResultsRef of
         Just getTmResultsRef -> run $ do
-          let tmResults = [(n, summarizeThreatModelIteration o entries) | (n, o, entries, _) <- tmResultsWithCov]
+          let tmResults = [(n, summarizeThreatModelIteration o entries) | (n, o, entries, _, _) <- tmResultsWithCov]
           tmRef <- getTmResultsRef
           modifyIORef tmRef $ \existing ->
             foldl'
@@ -691,7 +691,7 @@ positiveTestTraced opts groupName mGetTmResultsRef tms evs recorder iterIdx = do
               existing
               tmResults
         Nothing -> pure ()
-      tmTraces <- liftIO $ toThreatModelTraces (findTestIdIO recorder groupName) (redeemerTagger @state) tmResultsWithCov
+      tmTraces <- liftIO $ toThreatModelTraces (findTestIdIO recorder groupName) (redeemerTagger @state) [(n, o, e, c) | (n, o, e, c, _) <- tmResultsWithCov]
       let trace =
             IterationTrace
               { itIndex = iterIdx
@@ -700,6 +700,8 @@ positiveTestTraced opts groupName mGetTmResultsRef tms evs recorder iterIdx = do
               , itThreatModels = tmTraces
               }
       run $ recordIteration recorder groupName "positive" (covDataToSrcLocRanges mcsCoverageData) (toJSON trace)
+      let allMonitors = foldr (.) id [m | (_, _, _, _, m) <- tmResultsWithCov]
+      monitor allMonitors
       pure (property True)
 
 -- | Fast path: runs 'runActions' (no UTxO snapshots, no tx summaries, no JSON).
@@ -743,20 +745,21 @@ positiveTestFast opts mGetTmResultsRef tms evs = do
         allToRun = tmsToRun <> evs
     tmResultsWithCov <- liftIO $ forM allToRun $ \tm -> do
       let name = fromMaybe "Unnamed" (getThreatModelName tm)
-      ((outcome, traceEntries), tmFinalState) <-
+      ((outcome, traceEntries, monitors), tmFinalState) <-
         runMockchainIO (runThreatModelCheckTraced AutoSign tm envs) params state0
-      pure (name, outcome, traceEntries, mcsCoverageData tmFinalState)
+      pure (name, outcome, traceEntries, mcsCoverageData tmFinalState, monitors)
 
-    let tmResults = [(n, summarizeThreatModelIteration o entries) | (n, o, entries, _) <- tmResultsWithCov]
-        tmCoverage = mconcat [cov | (_, _, _, cov) <- tmResultsWithCov]
+    let tmResults = [(n, summarizeThreatModelIteration o entries) | (n, o, entries, _, _) <- tmResultsWithCov]
+        tmCoverage = mconcat [cov | (_, _, _, cov, _) <- tmResultsWithCov]
+        tmMonitors = [m | (_, _, _, _, m) <- tmResultsWithCov]
 
-    pure (finalState, tmResults, tmCoverage)
+    pure (finalState, tmResults, tmCoverage, tmMonitors)
 
   case result of
     (Left err, MockChainState{mcsCoverageData = covData}) -> do
       for_ coverageRef $ \ref -> liftIO $ modifyIORef ref (<> (covData <> coverageFromBalanceTxError err))
       pure (property False)
-    (Right (finalState, tmResults, tmCoverage), MockChainState{mcsCoverageData = covData}) -> do
+    (Right (finalState, tmResults, tmCoverage, tmMonitors), MockChainState{mcsCoverageData = covData}) -> do
       monitor (counterexample $ "Final state: " ++ show finalState)
       traverse_ (\ref -> liftIO $ modifyIORef ref (<> covData <> tmCoverage)) coverageRef
       case mGetTmResultsRef of
@@ -768,6 +771,8 @@ positiveTestFast opts mGetTmResultsRef tms evs = do
               existing
               tmResults
         Nothing -> pure ()
+      let allMonitors = foldr (.) id tmMonitors
+      monitor allMonitors
       pure (property True)
 
 -- | Create a test case for displaying threat model results

--- a/src/testing-interface/lib/Convex/ThreatModel.hs
+++ b/src/testing-interface/lib/Convex/ThreatModel.hs
@@ -474,20 +474,21 @@ runThreatModelCheck
   => SigningWallet
   -> ThreatModel a
   -> [ThreatModelEnv]
-  -> m ThreatModelOutcome
-runThreatModelCheck signingWallet = go False
+  -> m (ThreatModelOutcome, Property -> Property)
+runThreatModelCheck signingWallet = go False []
  where
-  go b _model [] = pure $ if b then TMPassed else TMSkipped
-  go b model (env : envs) = do
+  composeMonitors = foldr (.) id
+  go b mons _model [] = pure (if b then TMPassed else TMSkipped, composeMonitors mons)
+  go b mons model (env : envs) = do
     -- Resolve wallet: use provided or detect from transaction
     let resolvedWallet = case signingWallet of
           SignWith w -> Right w
           AutoSign -> TM.detectSigningWallet (currentTx env)
     case resolvedWallet of
-      Left err -> pure (TMError err) -- Continue to next env would lose the error, so return it
-      Right wallet -> checkInterp wallet model
+      Left err -> pure (TMError err, composeMonitors mons) -- Continue to next env would lose the error, so return it
+      Right wallet -> checkInterp wallet mons model
    where
-    checkInterp wallet = \case
+    checkInterp wallet mons' = \case
       Validate mods k -> do
         let (modifiedTx, modifiedUtxo) = applyTxModifier (currentTx env) (currentUTxOs env) mods
         params <- askNodeParams
@@ -495,23 +496,23 @@ runThreatModelCheck signingWallet = go False
         rebalanceResult <- TM.rebalanceAndSign wallet modifiedTx modifiedUtxo
         case rebalanceResult of
           Left _err ->
-            go b model envs -- Rebalancing failed, skip to next tx (like precondition failure)
+            go b mons' model envs -- Rebalancing failed, skip to next tx (like precondition failure)
           Right rebalancedTx -> do
             (report, covData) <- validateTxM params (currentSlot env) rebalancedTx modifiedUtxo
             modifyMockChainState $ \s -> ((), s & coverageData %~ (<> covData))
-            checkInterp wallet (k report)
+            checkInterp wallet mons' (k report)
       Generate gen _shr k -> do
         a <- liftIO $ QC.generate gen
-        checkInterp wallet (k a)
+        checkInterp wallet mons' (k a)
       GetCtx k ->
-        checkInterp wallet (k env)
-      Skip -> go b model envs
-      InPrecondition k -> checkInterp wallet (k False)
-      Fail err -> pure (TMFailed err)
-      Monitor _m k -> checkInterp wallet k -- No Property to wrap; drop monitoring
-      MonitorLocal _m k -> checkInterp wallet k -- No Property to wrap; drop monitoring
-      Done{} -> go True model envs
-      Named _n k -> checkInterp wallet k
+        checkInterp wallet mons' (k env)
+      Skip -> go b mons' model envs
+      InPrecondition k -> checkInterp wallet mons' (k False)
+      Fail err -> pure (TMFailed err, composeMonitors mons')
+      Monitor m k -> checkInterp wallet (m : mons') k
+      MonitorLocal m k -> checkInterp wallet (m : mons') k
+      Done{} -> go True mons' model envs
+      Named _n k -> checkInterp wallet mons' k
 
 -- | A single trace entry from a threat model check against one ThreatModelEnv.
 data ThreatModelCheckEntry = ThreatModelCheckEntry
@@ -540,20 +541,21 @@ runThreatModelCheckTraced
   => SigningWallet
   -> ThreatModel a
   -> [ThreatModelEnv]
-  -> m (ThreatModelOutcome, [ThreatModelCheckEntry])
-runThreatModelCheckTraced signingWallet = go False [] 0
+  -> m (ThreatModelOutcome, [ThreatModelCheckEntry], Property -> Property)
+runThreatModelCheckTraced signingWallet = go False [] [] 0
  where
-  go b acc _envIdx _model [] = pure (if b then TMPassed else TMSkipped, reverse acc)
-  go b acc envIdx model (env : envs) = do
+  composeMonitors = foldr (.) id
+  go b acc mons _envIdx _model [] = pure (if b then TMPassed else TMSkipped, reverse acc, composeMonitors mons)
+  go b acc mons envIdx model (env : envs) = do
     -- Resolve wallet: use provided or detect from transaction
     let resolvedWallet = case signingWallet of
           SignWith w -> Right w
           AutoSign -> TM.detectSigningWallet (currentTx env)
     case resolvedWallet of
-      Left err -> pure (TMError err, reverse acc)
-      Right wallet -> checkInterp wallet acc model
+      Left err -> pure (TMError err, reverse acc, composeMonitors mons)
+      Right wallet -> checkInterp wallet acc mons model
    where
-    checkInterp wallet acc' = \case
+    checkInterp wallet acc' mons' = \case
       Validate mods k -> do
         let (modifiedTx, modifiedUtxo) = applyTxModifier (currentTx env) (currentUTxOs env) mods
         params <- askNodeParams
@@ -571,7 +573,7 @@ runThreatModelCheckTraced signingWallet = go False [] 0
                     , tmceModifiedUtxo = modifiedUtxo
                     , tmceValidation = Nothing
                     }
-            go b (entry : acc') (envIdx + 1) model envs -- Rebalancing failed, skip to next tx
+            go b (entry : acc') mons' (envIdx + 1) model envs -- Rebalancing failed, skip to next tx
           Right rebalancedTx -> do
             (report, covData) <- validateTxM params (currentSlot env) rebalancedTx modifiedUtxo
             modifyMockChainState $ \s -> ((), s & coverageData %~ (<> covData))
@@ -585,19 +587,19 @@ runThreatModelCheckTraced signingWallet = go False [] 0
                     , tmceModifiedUtxo = modifiedUtxo
                     , tmceValidation = Just report
                     }
-            checkInterp wallet (entry : acc') (k report)
+            checkInterp wallet (entry : acc') mons' (k report)
       Generate gen _shr k -> do
         a <- liftIO $ QC.generate gen
-        checkInterp wallet acc' (k a)
+        checkInterp wallet acc' mons' (k a)
       GetCtx k ->
-        checkInterp wallet acc' (k env)
-      Skip -> go b acc' (envIdx + 1) model envs
-      InPrecondition k -> checkInterp wallet acc' (k False)
-      Fail err -> pure (TMFailed err, reverse acc')
-      Monitor _m k -> checkInterp wallet acc' k
-      MonitorLocal _m k -> checkInterp wallet acc' k
-      Done{} -> go True acc' (envIdx + 1) model envs
-      Named _n k -> checkInterp wallet acc' k
+        checkInterp wallet acc' mons' (k env)
+      Skip -> go b acc' mons' (envIdx + 1) model envs
+      InPrecondition k -> checkInterp wallet acc' mons' (k False)
+      Fail err -> pure (TMFailed err, reverse acc', composeMonitors mons')
+      Monitor m k -> checkInterp wallet acc' (m : mons') k
+      MonitorLocal m k -> checkInterp wallet acc' (m : mons') k
+      Done{} -> go True acc' mons' (envIdx + 1) model envs
+      Named _n k -> checkInterp wallet acc' mons' k
 
 {- | Check a precondition. If the argument threat model fails, the evaluation of the current
   transaction is skipped. If all transactions in an evaluation of `runThreatModel` are skipped

--- a/src/testing-interface/lib/Convex/ThreatModel/DatumBloat.hs
+++ b/src/testing-interface/lib/Convex/ThreatModel/DatumBloat.hs
@@ -63,100 +63,128 @@ module Convex.ThreatModel.DatumBloat (
   -- * List bloating attacks
   datumListBloatAttack,
   datumListBloatAttackWith,
+  datumListBloatAttackWithGen,
   bloatLists,
 
   -- * ByteString inflation attacks
   datumByteBloatAttack,
   datumByteBloatAttackWith,
+  datumByteBloatAttackWithGen,
   inflateBytes,
   inflateFirstListItem,
 ) where
 
 import Convex.ThreatModel
 import Data.ByteString qualified as BS
+import Test.QuickCheck (Gen, choose, shrinkIntegral)
 
-{- | Check for Datum Bloat vulnerabilities with default parameters.
-
-Appends 5 items of 100 bytes each to every list found in the datum.
-If the transaction still validates, the script doesn't limit datum field sizes.
+{- | Default datum-list-bloat attack. The number of items and item size are
+drawn per transaction from curated ranges, so QuickCheck explores the
+parameter space and shrinks counterexamples toward the smallest triggering
+values.
 -}
 datumListBloatAttack :: ThreatModel ()
-datumListBloatAttack = datumListBloatAttackWith 5 100
+datumListBloatAttack = datumListBloatAttackWithGen ((,) <$> choose (1, 20) <*> choose (1, 500))
 
-{- | Check for Datum Bloat vulnerabilities with configurable parameters.
-
-For a transaction with script outputs containing inline datums:
-
-* Recursively find all @ScriptDataList@ fields in the datum
-* Append @numItems@ large @ScriptDataBytes@ items to each list
-* Each appended item is @itemSize@ bytes of 0x42 ('B')
-* If the transaction still validates, the script doesn't enforce
-  field size limits - it only checks the fields it expects.
-
-This catches vulnerabilities where validators have unbounded list fields
-(like a list of messages or a list of signatures) that can be exploited
-to bloat the datum beyond spendable limits.
-
-@
-datumListBloatAttackWith 5 100  -- Add 5 items of 100 bytes each
-datumListBloatAttackWith 10 500 -- More aggressive: 10 items of 500 bytes
-@
+{- | Datum-list-bloat attack with fixed parameters. Keep using this for
+deterministic regression tests and golden seeds.
 -}
 datumListBloatAttackWith :: Int -> Int -> ThreatModel ()
-datumListBloatAttackWith numItems itemSize = Named ("Datum List Bloat Attack (" ++ show numItems ++ " items, " ++ show itemSize ++ " bytes)") $ do
-  -- Get all outputs from the transaction
-  outputs <- getTxOutputs
+datumListBloatAttackWith numItems itemSize = datumListBloatAttackWithGen (pure (numItems, itemSize))
 
-  -- Filter to script outputs with inline datums
-  let scriptOutputsWithDatum = filter isScriptOutputWithInlineDatum outputs
+{- | Datum-list-bloat attack parameterised by a generator for the number of
+items and the per-item byte size. This is the primitive the other two forms
+delegate to.
+-}
+datumListBloatAttackWithGen :: Gen (Int, Int) -> ThreatModel ()
+datumListBloatAttackWithGen gen =
+  Named "Datum List Bloat Attack" $ do
+    (numItems, itemSize) <- forAllTM gen shrinkPair
 
-  -- Precondition: there must be at least one script output with inline datum
-  threatPrecondition $ ensure (not $ null scriptOutputsWithDatum)
+    -- Skip iterations where the draw is too small to be a meaningful attack.
+    ensure (numItems >= 1 && itemSize >= 1)
 
-  -- Pick a target output
-  target <- pickAny scriptOutputsWithDatum
+    -- Precondition: transaction must spend a script input (otherwise no validator runs)
+    _ <- anyInputSuchThat (not . isKeyAddressAny . addressOf)
 
-  -- Extract the inline datum (we know it exists due to the filter)
-  originalDatum <- case getInlineDatum target of
-    Nothing -> failPrecondition "Script output missing inline datum"
-    Just originalDatum' -> pure originalDatum'
+    -- Get all outputs from the transaction
+    outputs <- getTxOutputs
 
-  -- Check if the datum contains any lists to bloat
-  unless (containsList originalDatum) $
-    failPrecondition "Datum contains no list fields to bloat"
+    -- Filter to script outputs with inline datums
+    let scriptOutputsWithDatum = filter isScriptOutputWithInlineDatum outputs
 
-  let bloatedDatum = bloatLists numItems itemSize originalDatum
+    -- Precondition: there must be at least one script output with inline datum
+    threatPrecondition $ ensure (not $ null scriptOutputsWithDatum)
 
-  counterexampleTM $
-    paragraph
-      [ "The transaction contains a script output at index"
-      , show (outputIx target)
-      , "with an inline datum containing list fields."
-      ]
+    -- Pick a target output
+    target <- pickAny scriptOutputsWithDatum
 
-  counterexampleTM $
-    paragraph
-      [ "Testing if the lists can be bloated with"
-      , show numItems
-      , "items of"
-      , show itemSize
-      , "bytes each while still passing validation."
-      ]
+    -- Extract the inline datum (we know it exists due to the filter)
+    originalDatum <- case getInlineDatum target of
+      Nothing -> failPrecondition "Script output missing inline datum"
+      Just originalDatum' -> pure originalDatum'
 
-  counterexampleTM $
-    paragraph
-      [ "If this validates, the script doesn't enforce datum field size limits."
-      , "An attacker could exploit this to:"
-      , "1) Inflate the datum beyond transaction size limits"
-      , "2) Increase execution costs for processing the datum"
-      , "3) Potentially lock funds permanently if limits are exceeded"
-      ]
+    -- Check if the datum contains any lists to bloat
+    unless (containsList originalDatum) $
+      failPrecondition "Datum contains no list fields to bloat"
 
-  -- Try to validate with the bloated datum
-  shouldNotValidate $ changeDatumOf target (toInlineDatum bloatedDatum)
+    let bloatedDatum = bloatLists numItems itemSize originalDatum
+
+    counterexampleTM $
+      paragraph
+        [ "The transaction contains a script output at index"
+        , show (outputIx target)
+        , "with an inline datum containing list fields."
+        ]
+
+    counterexampleTM $
+      paragraph
+        [ "Testing if the lists can be bloated with"
+        , show numItems
+        , "items of"
+        , show itemSize
+        , "bytes each while still passing validation."
+        ]
+
+    counterexampleTM $
+      paragraph
+        [ "If this validates, the script doesn't enforce datum field size limits."
+        , "An attacker could exploit this to:"
+        , "1) Inflate the datum beyond transaction size limits"
+        , "2) Increase execution costs for processing the datum"
+        , "3) Potentially lock funds permanently if limits are exceeded"
+        ]
+
+    tabulateTM "items" [bucketItems numItems]
+    tabulateTM "item bytes" [bucketSize itemSize]
+
+    -- Try to validate with the bloated datum
+    shouldNotValidate $ changeDatumOf target (toInlineDatum bloatedDatum)
  where
   unless False action = action
   unless True _ = pure ()
+
+-- | Shrink a pair of positive integers toward (1, 1).
+shrinkPair :: (Int, Int) -> [(Int, Int)]
+shrinkPair (a, b) =
+  [(a', b) | a' <- shrinkPositive a]
+    ++ [(a, b') | b' <- shrinkPositive b]
+
+-- | Coarse bucket for the item-count distribution report.
+bucketItems :: Int -> String
+bucketItems n
+  | n <= 5 = "001-005"
+  | n <= 10 = "006-010"
+  | n <= 15 = "011-015"
+  | otherwise = "016-020"
+
+-- | Coarse bucket for the per-item byte-size distribution report.
+bucketSize :: Int -> String
+bucketSize n
+  | n <= 50 = "001-050"
+  | n <= 100 = "051-100"
+  | n <= 250 = "101-250"
+  | otherwise = "251-500"
 
 {- | Recursively bloat all list fields in a @ScriptData@ value.
 
@@ -216,80 +244,79 @@ toInlineDatum sd =
 -- ByteString Inflation Attack
 -- ----------------------------------------------------------------------------
 
-{- | Test if ByteString fields in the datum can be inflated.
-
-This catches validators that don't limit the size of individual
-ByteString fields (e.g., messages, names, arbitrary data).
-
-The attack replaces every @ScriptDataBytes@ field found at any depth
-(except the first field of the top-level constructor, typically an owner hash)
-with a much larger ByteString.
-
-For a tipjar datum @Con0(owner_hash, [\"Hello\"])@:
-
-* @owner_hash@ is preserved (first field must match for validation)
-* @\"Hello\"@ inside the list gets inflated to 10KB of @0x42@
-* Result: @Con0(owner_hash, [<10KB bytes>])@
-* The validator checks: @list.push([], <10KB bytes>) == [<10KB bytes>]@ → True!
-
-This enables a DoS attack where an attacker can:
-
-1. Create a valid transaction with a small message
-2. Intercept/frontrun and replace the message with a huge ByteArray
-3. The bloated datum may exceed transaction limits for future spending
-
-Default inflation size is 10,000 bytes (10KB).
+{- | Default datum-byte-bloat attack. The inflation size is drawn per
+transaction from a curated range, so QuickCheck explores the parameter
+space and shrinks counterexamples toward the smallest triggering value.
 -}
 datumByteBloatAttack :: ThreatModel ()
-datumByteBloatAttack = datumByteBloatAttackWith 10000
+datumByteBloatAttack = datumByteBloatAttackWithGen (choose (1, 10000))
 
-{- | Check for ByteString inflation vulnerabilities with configurable size.
-
-This attack is specifically designed to catch validators like tipjar that:
-1. Allow adding items to a list
-2. Check that @list.push(old_items, new_item) == new_items@
-3. But DON'T limit the SIZE of @new_item@
-
-The attack inflates only the FIRST item in lists (typically the newly-added
-item), leaving existing items unchanged so the structural check passes.
-
-@
-datumByteBloatAttackWith 10000   -- Inflate first list item to 10KB
-datumByteBloatAttackWith 50000   -- More aggressive: 50KB
-@
+{- | Datum-byte-bloat attack with a fixed inflation size. Keep using this
+for deterministic regression tests and golden seeds.
 -}
 datumByteBloatAttackWith :: Int -> ThreatModel ()
-datumByteBloatAttackWith inflatedSize = Named ("Datum Byte Bloat Attack (" ++ show inflatedSize ++ " bytes)") $ do
-  outputs <- getTxOutputs
-  let scriptOutputsWithDatum = filter isScriptOutputWithInlineDatum outputs
-  threatPrecondition $ ensure (not $ null scriptOutputsWithDatum)
-  target <- pickAny scriptOutputsWithDatum
+datumByteBloatAttackWith = datumByteBloatAttackWithGen . pure
 
-  originalDatum <- case getInlineDatum target of
-    Nothing -> failPrecondition "Script output missing inline datum"
-    Just originalDatum' -> pure originalDatum'
+{- | Datum-byte-bloat attack parameterised by a generator for the inflation
+size. This is the primitive the other two forms delegate to.
+-}
+datumByteBloatAttackWithGen :: Gen Int -> ThreatModel ()
+datumByteBloatAttackWithGen gen =
+  Named "Datum Byte Bloat Attack" $ do
+    inflatedSize <- forAllTM gen shrinkPositive
 
-  let bloatedDatum = inflateFirstListItem inflatedSize originalDatum
+    -- Skip iterations where the draw is too small to be a meaningful attack.
+    ensure (inflatedSize >= 1)
 
-  -- Only proceed if something actually changed (datum has list with items to inflate)
-  threatPrecondition $ ensure (bloatedDatum /= originalDatum)
+    -- Precondition: transaction must spend a script input (otherwise no validator runs)
+    _ <- anyInputSuchThat (not . isKeyAddressAny . addressOf)
 
-  counterexampleTM $
-    paragraph
-      [ "The transaction contains a script output with an inline datum."
-      , "Testing if the first item in list fields can be inflated to"
-      , show inflatedSize
-      , "bytes while still passing validation."
-      ]
+    outputs <- getTxOutputs
+    let scriptOutputsWithDatum = filter isScriptOutputWithInlineDatum outputs
+    threatPrecondition $ ensure (not $ null scriptOutputsWithDatum)
+    target <- pickAny scriptOutputsWithDatum
 
-  counterexampleTM $
-    paragraph
-      [ "If this validates, the script doesn't limit ByteString field sizes,"
-      , "enabling a datum bloat DoS attack where an attacker can add"
-      , "a huge message/data item to bloat the datum beyond spendable limits."
-      ]
+    originalDatum <- case getInlineDatum target of
+      Nothing -> failPrecondition "Script output missing inline datum"
+      Just originalDatum' -> pure originalDatum'
 
-  shouldNotValidate $ changeDatumOf target (toInlineDatum bloatedDatum)
+    let bloatedDatum = inflateFirstListItem inflatedSize originalDatum
+
+    -- Only proceed if something actually changed (datum has list with items to inflate)
+    threatPrecondition $ ensure (bloatedDatum /= originalDatum)
+
+    counterexampleTM $
+      paragraph
+        [ "The transaction contains a script output with an inline datum."
+        , "Testing if the first item in list fields can be inflated to"
+        , show inflatedSize
+        , "bytes while still passing validation."
+        ]
+
+    counterexampleTM $
+      paragraph
+        [ "If this validates, the script doesn't limit ByteString field sizes,"
+        , "enabling a datum bloat DoS attack where an attacker can add"
+        , "a huge message/data item to bloat the datum beyond spendable limits."
+        ]
+
+    tabulateTM "inflated bytes" [bucket inflatedSize]
+
+    shouldNotValidate $ changeDatumOf target (toInlineDatum bloatedDatum)
+
+{- | Shrink a positive integer toward 1 (the smallest meaningful value),
+never reaching 0.
+-}
+shrinkPositive :: Int -> [Int]
+shrinkPositive = filter (>= 1) . shrinkIntegral
+
+-- | Coarse bucket for the inflation-size distribution report.
+bucket :: Int -> String
+bucket n
+  | n <= 1000 = "0001-1000"
+  | n <= 5000 = "1001-5000"
+  | n <= 10000 = "5001-10000"
+  | otherwise = "10000+"
 
 {- | Replace all @ScriptDataBytes@ with inflated versions.
 

--- a/src/testing-interface/lib/Convex/ThreatModel/InvalidDatumIndex.hs
+++ b/src/testing-interface/lib/Convex/ThreatModel/InvalidDatumIndex.hs
@@ -55,85 +55,103 @@ If it does, the validator has an Invalid Datum Index vulnerability.
 module Convex.ThreatModel.InvalidDatumIndex (
   invalidDatumIndexAttack,
   invalidDatumIndexAttackWith,
+  invalidDatumIndexAttackWithGen,
   replaceConstrIndex,
 ) where
 
 import Convex.ThreatModel
+import Test.QuickCheck (Gen, choose)
 
-{- | Check for Invalid Datum Index vulnerabilities using constructor index 5.
-
-This is the default configuration, which replaces the constructor index of any
-inline @Constr@ datum on a script output with @5@. Valid PingPong indices are
-0 (Pinged), 1 (Ponged), and 2 (Stopped), so @5@ is safely out-of-range for all
-known state machines in this codebase. If the transaction still validates, the
-validator has a permissive datum index check.
+{- | Default invalid-datum-index attack. The replacement constructor index is
+drawn per transaction from a curated range starting at 3 (above the typical
+0, 1, 2 indices of most Plutus sum types), so QuickCheck explores the
+parameter space without accidentally hitting a valid index.
 -}
 invalidDatumIndexAttack :: ThreatModel ()
-invalidDatumIndexAttack = invalidDatumIndexAttackWith 5
+invalidDatumIndexAttack = invalidDatumIndexAttackWithGen (choose (3, 100))
 
-{- | Check for Invalid Datum Index vulnerabilities with a configurable
-constructor index.
-
-For a transaction with script outputs containing inline datums:
-
-* Replace the @Constr@ index of the datum with @invalidIdx@
-* Leave the constructor fields unchanged so any field parsing still succeeds
-* If the transaction still validates, the validator does not reject
-  out-of-range constructor indices — it may have a permissive catch-all.
-
-Choose @invalidIdx@ to be outside the range of all valid constructors for the
-script under test (e.g., @5@ for a 3-constructor type, @99@ for extra clarity).
+{- | Invalid-datum-index attack with a fixed constructor index. Keep using
+this for deterministic regression tests and golden seeds.
 -}
 invalidDatumIndexAttackWith :: Integer -> ThreatModel ()
-invalidDatumIndexAttackWith invalidIdx = Named ("Invalid Datum Index Attack (index " ++ show invalidIdx ++ ")") $ do
-  -- Precondition: transaction must spend a script input (otherwise no validator runs)
-  _ <- anyInputSuchThat (not . isKeyAddressAny . addressOf)
+invalidDatumIndexAttackWith = invalidDatumIndexAttackWithGen . pure
 
-  -- Get all outputs from the transaction
-  outputs <- getTxOutputs
+{- | Invalid-datum-index attack parameterised by a generator for the
+replacement constructor index. This is the primitive the other two forms
+delegate to.
+-}
+invalidDatumIndexAttackWithGen :: Gen Integer -> ThreatModel ()
+invalidDatumIndexAttackWithGen invalidIdxGen =
+  Named "Invalid Datum Index Attack" $ do
+    invalidIdx <- forAllTM invalidIdxGen noShrink
 
-  -- Filter to script outputs with inline datums that carry a Constr datum
-  let scriptOutputsWithConstr = filter isScriptOutputWithConstrInlineDatum outputs
+    -- Negative indices belong to the negative-integer attack, not this model.
+    ensure (invalidIdx >= 0)
 
-  -- Precondition: there must be at least one eligible target output
-  threatPrecondition $ ensure (not $ null scriptOutputsWithConstr)
+    -- Precondition: transaction must spend a script input (otherwise no validator runs)
+    _ <- anyInputSuchThat (not . isKeyAddressAny . addressOf)
 
-  -- Pick a target output
-  target <- pickAny scriptOutputsWithConstr
+    -- Get all outputs from the transaction
+    outputs <- getTxOutputs
 
-  -- Extract the inline datum (we know it exists due to the filter above)
-  originalDatum <- case getInlineDatum target of
-    Nothing -> failPrecondition "Script output missing inline datum"
-    Just d -> pure d
+    -- Filter to script outputs with inline datums that carry a Constr datum
+    let scriptOutputsWithConstr = filter isScriptOutputWithConstrInlineDatum outputs
 
-  let mutatedDatum = replaceConstrIndex invalidIdx originalDatum
+    -- Precondition: there must be at least one eligible target output
+    threatPrecondition $ ensure (not $ null scriptOutputsWithConstr)
 
-  counterexampleTM $
-    paragraph
-      [ "The transaction contains a script output at index"
-      , show (outputIx target)
-      , "with an inline Constr datum."
-      ]
+    -- Pick a target output
+    target <- pickAny scriptOutputsWithConstr
 
-  counterexampleTM $
-    paragraph
-      [ "Testing if the datum's constructor index can be replaced with"
-      , show invalidIdx
-      , "while the fields are left unchanged, and the transaction still validates."
-      ]
+    -- Extract the inline datum (we know it exists due to the filter above)
+    originalDatum <- case getInlineDatum target of
+      Nothing -> failPrecondition "Script output missing inline datum"
+      Just d -> pure d
 
-  counterexampleTM $
-    paragraph
-      [ "If this validates, the script's FromData parser accepts out-of-range"
-      , "constructor indices (e.g., via a catch-all branch). An attacker could"
-      , "exploit this to:"
-      , "1) Confuse the validator about which state the datum represents"
-      , "2) Bypass state-transition guards that depend on the constructor index"
-      , "3) Lock funds permanently with an unspendable corrupted datum"
-      ]
+    let mutatedDatum = replaceConstrIndex invalidIdx originalDatum
 
-  -- This SHOULD fail - if it validates, the contract is vulnerable.
-  shouldNotValidate $ changeDatumOf target (toInlineDatum mutatedDatum)
+    counterexampleTM $
+      paragraph
+        [ "The transaction contains a script output at index"
+        , show (outputIx target)
+        , "with an inline Constr datum."
+        ]
+
+    counterexampleTM $
+      paragraph
+        [ "Testing if the datum's constructor index can be replaced with"
+        , show invalidIdx
+        , "while the fields are left unchanged, and the transaction still validates."
+        ]
+
+    counterexampleTM $
+      paragraph
+        [ "If this validates, the script's FromData parser accepts out-of-range"
+        , "constructor indices (e.g., via a catch-all branch). An attacker could"
+        , "exploit this to:"
+        , "1) Confuse the validator about which state the datum represents"
+        , "2) Bypass state-transition guards that depend on the constructor index"
+        , "3) Lock funds permanently with an unspendable corrupted datum"
+        ]
+
+    tabulateTM "invalid index" [bucketIdx invalidIdx]
+
+    -- This SHOULD fail - if it validates, the contract is vulnerable.
+    shouldNotValidate $ changeDatumOf target (toInlineDatum mutatedDatum)
+
+{- | No shrinking: shrinking toward 0 could produce a valid constructor index,
+making the attack vacuous and causing a false 'TMFailed'.
+-}
+noShrink :: a -> [a]
+noShrink _ = []
+
+-- | Coarse bucket for the invalid-index distribution report.
+bucketIdx :: Integer -> String
+bucketIdx n
+  | n <= 10 = "003-010"
+  | n <= 50 = "011-050"
+  | n <= 100 = "051-100"
+  | otherwise = "101+"
 
 -- ---------------------------------------------------------------------------
 -- Helpers

--- a/src/testing-interface/lib/Convex/ThreatModel/LargeData.hs
+++ b/src/testing-interface/lib/Convex/ThreatModel/LargeData.hs
@@ -49,80 +49,85 @@ If it does, the validator has a Large Data Attack vulnerability.
 module Convex.ThreatModel.LargeData (
   largeDataAttack,
   largeDataAttackWith,
+  largeDataAttackWithGen,
   bloatData,
 ) where
 
 import Convex.ThreatModel
+import Test.QuickCheck (Gen, choose, shrinkIntegral)
 
-{- | Check for Large Data Attack vulnerabilities with 1000 extra fields.
-
-This is the default configuration that appends 1000 extra @ScriptDataNumber 42@
-fields to any inline datum on a script output. If the transaction still
-validates, the script's datum parser is permissive and vulnerable.
+{- | Default large-data attack. The number of injected fields is drawn per
+transaction from a curated range, so QuickCheck explores the parameter space
+and shrinks counterexamples toward the smallest triggering value.
 -}
 largeDataAttack :: ThreatModel ()
-largeDataAttack = largeDataAttackWith 1000
+largeDataAttack = largeDataAttackWithGen (choose (1, 1000))
 
-{- | Check for Large Data Attack vulnerabilities with a configurable number
-of extra fields.
-
-For a transaction with script outputs containing inline datums:
-
-* Try bloating the datum by appending @n@ extra fields
-* If the transaction still validates, the script doesn't strictly validate
-  its datum structure - it only checks expected fields and ignores extras.
-
-This catches a vulnerability where different parsers may interpret the same
-on-chain data differently, leading to potential exploits.
+{- | Large-data attack with a fixed field count. Keep using this for
+deterministic regression tests and golden seeds.
 -}
 largeDataAttackWith :: Int -> ThreatModel ()
-largeDataAttackWith n = Named ("Large Data Attack (max " ++ show n ++ " fields)") $ do
-  -- Precondition: transaction must spend a script input (otherwise no validator runs)
-  _ <- anyInputSuchThat (not . isKeyAddressAny . addressOf)
+largeDataAttackWith = largeDataAttackWithGen . pure
 
-  -- Get all outputs from the transaction
-  outputs <- getTxOutputs
+{- | Large-data attack parameterised by a generator for the number of extra
+@Constr@ fields injected into the target inline datum. This is the primitive
+the other two forms delegate to.
+-}
+largeDataAttackWithGen :: Gen Int -> ThreatModel ()
+largeDataAttackWithGen fieldsGen =
+  Named "Large Data Attack" $ do
+    n <- forAllTM fieldsGen shrinkPositive
 
-  -- Filter to script outputs with inline datums
-  let scriptOutputsWithDatum = filter isScriptOutputWithInlineDatum outputs
+    -- Skip iterations where the draw is too small to be a meaningful attack.
+    ensure (n >= 1)
 
-  -- Precondition: there must be at least one script output with inline datum
-  threatPrecondition $ ensure (not $ null scriptOutputsWithDatum)
+    -- Precondition: transaction must spend a script input (otherwise no validator runs)
+    _ <- anyInputSuchThat (not . isKeyAddressAny . addressOf)
 
-  -- Pick a target output
-  target <- pickAny scriptOutputsWithDatum
+    -- Get all outputs from the transaction
+    outputs <- getTxOutputs
 
-  -- Extract the inline datum (we know it exists due to the filter)
-  originalDatum <- case getInlineDatum target of
-    Nothing -> failPrecondition "Script output missing inline datum"
-    Just originalDatum' -> pure originalDatum'
+    -- Filter to script outputs with inline datums
+    let scriptOutputsWithDatum = filter isScriptOutputWithInlineDatum outputs
 
-  let bloatedDatum = bloatData n originalDatum
+    -- Precondition: there must be at least one script output with inline datum
+    threatPrecondition $ ensure (not $ null scriptOutputsWithDatum)
 
-  counterexampleTM $
-    paragraph
-      [ "The transaction contains a script output at index"
-      , show (outputIx target)
-      , "with an inline datum."
-      ]
+    -- Pick a target output
+    target <- pickAny scriptOutputsWithDatum
 
-  counterexampleTM $
-    paragraph
-      [ "Testing if the datum can be bloated with"
-      , show n
-      , "extra fields while still passing validation."
-      ]
+    -- Extract the inline datum (we know it exists due to the filter)
+    originalDatum <- case getInlineDatum target of
+      Nothing -> failPrecondition "Script output missing inline datum"
+      Just originalDatum' -> pure originalDatum'
 
-  counterexampleTM $
-    paragraph
-      [ "If this validates, the script's FromData parser is permissive"
-      , "and ignores extra Constr fields. An attacker could exploit this"
-      , "to make a single datum satisfy multiple validators,"
-      , "or to bypass certain datum-based checks."
-      ]
+    let bloatedDatum = bloatData n originalDatum
 
-  -- Try to validate with the bloated datum
-  shouldNotValidate $ changeDatumOf target (toInlineDatum bloatedDatum)
+    counterexampleTM $
+      paragraph
+        [ "Injecting " ++ show n
+        , "extra Constr fields into the inline datum of output"
+        , show (outputIx target)
+        , "and asserting the transaction no longer validates."
+        ]
+    tabulateTM "fields injected" [bucket n]
+
+    -- Try to validate with the bloated datum
+    shouldNotValidate $ changeDatumOf target (toInlineDatum bloatedDatum)
+
+{- | Shrink a positive integer toward 1 (the smallest meaningful value),
+never reaching 0.
+-}
+shrinkPositive :: Int -> [Int]
+shrinkPositive = filter (>= 1) . shrinkIntegral
+
+-- | Coarse bucket for the parameter distribution report.
+bucket :: Int -> String
+bucket n
+  | n <= 10 = "001-010"
+  | n <= 100 = "011-100"
+  | n <= 500 = "101-500"
+  | otherwise = "501-1000"
 
 {- | Bloat a @ScriptData@ value by appending extra fields to a @Constr@.
 

--- a/src/testing-interface/lib/Convex/ThreatModel/LargeValue.hs
+++ b/src/testing-interface/lib/Convex/ThreatModel/LargeValue.hs
@@ -52,6 +52,7 @@ has a Large Value Attack vulnerability.
 module Convex.ThreatModel.LargeValue (
   largeValueAttack,
   largeValueAttackWith,
+  largeValueAttackWithGen,
 ) where
 
 import Cardano.Api qualified as C
@@ -59,90 +60,107 @@ import Convex.ThreatModel
 import Convex.ThreatModel.TxModifier (addPlutusScriptMint, alwaysSucceedsMintingPolicy)
 import Data.ByteString.Char8 qualified as BS
 import GHC.Exts (fromList)
+import Test.QuickCheck (Gen, choose, shrinkIntegral)
 
-{- | Check for Large Value Attack vulnerabilities with 50 junk tokens.
-
-This is the default configuration that mints 50 unique tokens and adds them
-to a script output. If the transaction still validates, the script doesn't
-properly validate the value structure of its outputs.
+{- | Default large-value attack. The number of junk tokens is drawn per
+transaction from a curated range, so QuickCheck explores the parameter space
+and shrinks counterexamples toward the smallest triggering value.
 -}
 largeValueAttack :: ThreatModel ()
-largeValueAttack = largeValueAttackWith 50
+largeValueAttack = largeValueAttackWithGen (choose (1, 100))
 
-{- | Check for Large Value Attack vulnerabilities with a configurable number
-of junk tokens.
-
-For a transaction with script outputs:
-
-* Mint @n@ unique junk tokens using an always-succeeds minting policy
-* Add these tokens to a script output's value
-* If the transaction still validates, the script doesn't validate
-  the structure of values being created - it may only check amounts.
-
-This catches a vulnerability where validators use permissive value checks
-like @valuePaidTo addr >= expected@ instead of exact matching, allowing
-attackers to inflate UTxO min-Ada requirements or lock funds permanently.
+{- | Large-value attack with a fixed junk-token count. Keep using this for
+deterministic regression tests and golden seeds.
 -}
 largeValueAttackWith :: Int -> ThreatModel ()
-largeValueAttackWith numTokens = Named ("Large Value Attack (" ++ show numTokens ++ " tokens)") $ do
-  -- Get all outputs from the transaction
-  outputs <- getTxOutputs
+largeValueAttackWith = largeValueAttackWithGen . pure
 
-  -- Filter to script outputs (NOT key addresses)
-  let scriptOutputs = filter (not . isKeyAddressAny . addressOf) outputs
+{- | Large-value attack parameterised by a generator for the number of junk
+tokens minted and added to a script output. This is the primitive the other
+two forms delegate to.
+-}
+largeValueAttackWithGen :: Gen Int -> ThreatModel ()
+largeValueAttackWithGen numTokensGen =
+  Named "Large Value Attack" $ do
+    numTokens <- forAllTM numTokensGen shrinkPositive
 
-  -- Precondition: there must be at least one script output
-  threatPrecondition $ ensure (not $ null scriptOutputs)
+    -- Skip iterations where the draw is too small to be a meaningful attack.
+    ensure (numTokens >= 1)
 
-  -- Pick a target script output
-  target <- pickAny scriptOutputs
+    -- Get all outputs from the transaction
+    outputs <- getTxOutputs
 
-  -- Create junk tokens by minting with the always-succeeds policy
-  let policyId = C.PolicyId $ hashScript (C.PlutusScript C.PlutusScriptV2 alwaysSucceedsMintingPolicy)
-      junkTokens =
-        [ (C.UnsafeAssetName $ BS.pack $ "junk" ++ show i, C.Quantity 1)
-        | i <- [1 .. numTokens]
+    -- Filter to script outputs (NOT key addresses)
+    let scriptOutputs = filter (not . isKeyAddressAny . addressOf) outputs
+
+    -- Precondition: there must be at least one script output
+    threatPrecondition $ ensure (not $ null scriptOutputs)
+
+    -- Pick a target script output
+    target <- pickAny scriptOutputs
+
+    -- Create junk tokens by minting with the always-succeeds policy
+    let policyId = C.PolicyId $ hashScript (C.PlutusScript C.PlutusScriptV2 alwaysSucceedsMintingPolicy)
+        junkTokens =
+          [ (C.UnsafeAssetName $ BS.pack $ "junk" ++ show i, C.Quantity 1)
+          | i <- [1 .. numTokens]
+          ]
+        junkValue =
+          fromList
+            [ (C.AssetId policyId name, qty)
+            | (name, qty) <- junkTokens
+            ]
+        bloatedValue = valueOf target <> junkValue
+
+    counterexampleTM $
+      paragraph
+        [ "The transaction contains a script output at index"
+        , show (outputIx target)
+        , "."
         ]
-      junkValue =
-        fromList
-          [ (C.AssetId policyId name, qty)
-          | (name, qty) <- junkTokens
-          ]
-      bloatedValue = valueOf target <> junkValue
 
-  counterexampleTM $
-    paragraph
-      [ "The transaction contains a script output at index"
-      , show (outputIx target)
-      , "."
-      ]
+    counterexampleTM $
+      paragraph
+        [ "Testing if"
+        , show numTokens
+        , "junk tokens can be minted and added to the output's value"
+        , "while still passing validation."
+        ]
 
-  counterexampleTM $
-    paragraph
-      [ "Testing if"
-      , show numTokens
-      , "junk tokens can be minted and added to the output's value"
-      , "while still passing validation."
-      ]
+    counterexampleTM $
+      paragraph
+        [ "If this validates, the script's value validation is permissive."
+        , "An attacker could exploit this to:"
+        , "1) Increase min-UTxO requirements, locking victim's Ada"
+        , "2) Inflate transaction sizes, increasing spending costs"
+        , "3) Potentially lock funds permanently if size limits are exceeded"
+        ]
 
-  counterexampleTM $
-    paragraph
-      [ "If this validates, the script's value validation is permissive."
-      , "An attacker could exploit this to:"
-      , "1) Increase min-UTxO requirements, locking victim's Ada"
-      , "2) Inflate transaction sizes, increasing spending costs"
-      , "3) Potentially lock funds permanently if size limits are exceeded"
-      ]
+    tabulateTM "junk tokens" [bucket numTokens]
 
-  -- Create mint modifiers for all junk tokens
-  let mintModifiers =
-        mconcat
-          [ addPlutusScriptMint alwaysSucceedsMintingPolicy name qty (toScriptData ())
-          | (name, qty) <- junkTokens
-          ]
+    -- Create mint modifiers for all junk tokens
+    let mintModifiers =
+          mconcat
+            [ addPlutusScriptMint alwaysSucceedsMintingPolicy name qty (toScriptData ())
+            | (name, qty) <- junkTokens
+            ]
 
-  -- This SHOULD fail - if it validates, the contract is vulnerable
-  -- The attack: mint junk tokens AND add them to the target output
-  shouldNotValidate $
-    changeValueOf target bloatedValue
-      <> mintModifiers
+    -- This SHOULD fail - if it validates, the contract is vulnerable
+    -- The attack: mint junk tokens AND add them to the target output
+    shouldNotValidate $
+      changeValueOf target bloatedValue
+        <> mintModifiers
+
+{- | Shrink a positive integer toward 1 (the smallest meaningful value),
+never reaching 0.
+-}
+shrinkPositive :: Int -> [Int]
+shrinkPositive = filter (>= 1) . shrinkIntegral
+
+-- | Coarse bucket for the parameter distribution report.
+bucket :: Int -> String
+bucket n
+  | n <= 10 = "001-010"
+  | n <= 50 = "011-050"
+  | n <= 100 = "051-100"
+  | otherwise = "101+"

--- a/src/testing-interface/lib/Convex/ThreatModel/ValueUnderpayment.hs
+++ b/src/testing-interface/lib/Convex/ThreatModel/ValueUnderpayment.hs
@@ -51,101 +51,113 @@ the validator has a Value Underpayment vulnerability.
 module Convex.ThreatModel.ValueUnderpayment (
   valueUnderpaymentAttack,
   valueUnderpaymentAttackWith,
+  valueUnderpaymentAttackWithGen,
 ) where
 
 import Cardano.Api qualified as C
 import Convex.ThreatModel
+import Test.QuickCheck (Gen, choose, shrinkRealFrac)
 
 -- | Minimum ADA to leave in the output (to avoid min-UTxO violations)
 minOutputAda :: C.Lovelace
 minOutputAda = 2_000_000
 
-{- | Check for Value Underpayment vulnerabilities by halving the ADA value.
-
-This is the default configuration that reduces the ADA in a script output
-by 50%. If the transaction still validates, the script doesn't properly
-verify that output values match expected amounts.
+{- | Default value-underpayment attack. The reduction factor is drawn per
+transaction from a curated range, so QuickCheck explores the parameter space
+and shrinks counterexamples toward the smallest triggering value.
 -}
 valueUnderpaymentAttack :: ThreatModel ()
-valueUnderpaymentAttack = valueUnderpaymentAttackWith 0.5
+valueUnderpaymentAttack = valueUnderpaymentAttackWithGen (choose (0.01, 0.99))
 
-{- | Check for Value Underpayment vulnerabilities with a configurable
-reduction factor.
-
-For a transaction with script outputs:
-
-* Find a script output with ADA value
-* Reduce its ADA value by the given factor (e.g., 0.5 = halve it)
-* Keep the datum unchanged
-* If the transaction still validates, the script doesn't verify
-  that output value matches the expected amount based on datum.
-
-@reductionFactor@ should be between 0 and 1:
-- 0.5 means reduce to 50% of original value
-- 0.25 means reduce to 25% of original value
-- 0.9 means reduce to 10% of original value (keep only 10%)
-
-The attack ensures at least 'minOutputAda' remains to avoid min-UTxO failures.
+{- | Value-underpayment attack with a fixed reduction factor. Keep using
+this for deterministic regression tests and golden seeds.
 -}
 valueUnderpaymentAttackWith :: Double -> ThreatModel ()
-valueUnderpaymentAttackWith reductionFactor = Named ("Value Underpayment Attack (" ++ show (reductionFactor * 100) ++ "% reduction)") $ do
-  -- Get all outputs from the transaction
-  outputs <- getTxOutputs
+valueUnderpaymentAttackWith = valueUnderpaymentAttackWithGen . pure
 
-  -- Filter to script outputs (NOT key addresses)
-  let scriptOutputs = filter (not . isKeyAddressAny . addressOf) outputs
+{- | Value-underpayment attack parameterised by a generator for the ADA
+reduction factor (fraction of the original ADA removed from a script output).
+This is the primitive the other two forms delegate to.
+-}
+valueUnderpaymentAttackWithGen :: Gen Double -> ThreatModel ()
+valueUnderpaymentAttackWithGen reductionFactorGen =
+  Named "Value Underpayment Attack" $ do
+    reductionFactor <- forAllTM reductionFactorGen shrinkPositiveDouble
 
-  -- Precondition: there must be at least one script output
-  threatPrecondition $ ensure (not $ null scriptOutputs)
+    -- Skip iterations where the draw is too small to be a meaningful attack.
+    ensure (reductionFactor > 0)
 
-  -- Further filter to outputs that have enough ADA to be reduced
-  let hasEnoughAda out =
-        let adaValue = C.selectLovelace (valueOf out)
-         in adaValue > minOutputAda
-      reducibleOutputs = filter hasEnoughAda scriptOutputs
+    -- Get all outputs from the transaction
+    outputs <- getTxOutputs
 
-  -- Precondition: there must be at least one script output with enough ADA
-  threatPrecondition $ ensure (not $ null reducibleOutputs)
+    -- Filter to script outputs (NOT key addresses)
+    let scriptOutputs = filter (not . isKeyAddressAny . addressOf) outputs
 
-  -- Pick a target script output
-  target <- pickAny reducibleOutputs
+    -- Precondition: there must be at least one script output
+    threatPrecondition $ ensure (not $ null scriptOutputs)
 
-  -- Calculate reduced value
-  let currentValue = valueOf target
-      currentAda = C.selectLovelace currentValue
-      -- Calculate reduced ADA, ensuring we don't go below minimum
-      -- Lovelace has a Num instance, so we can use numeric operations
-      reducedAda = max minOutputAda (fromInteger $ round (fromIntegral currentAda * (1 - reductionFactor)))
-      adaDifference = C.negateValue $ C.lovelaceToValue (currentAda - reducedAda)
-      reducedValue = currentValue <> adaDifference
+    -- Further filter to outputs that have enough ADA to be reduced
+    let hasEnoughAda out =
+          let adaValue = C.selectLovelace (valueOf out)
+           in adaValue > minOutputAda
+        reducibleOutputs = filter hasEnoughAda scriptOutputs
 
-  counterexampleTM $
-    paragraph
-      [ "The transaction contains a script output at index"
-      , show (outputIx target)
-      , "."
-      ]
+    -- Precondition: there must be at least one script output with enough ADA
+    threatPrecondition $ ensure (not $ null reducibleOutputs)
 
-  counterexampleTM $
-    paragraph
-      [ "Testing if the ADA value can be reduced from"
-      , show currentAda
-      , "to"
-      , show reducedAda
-      , "(reduction factor:"
-      , show (reductionFactor * 100) ++ "%)"
-      , "while keeping the datum unchanged."
-      ]
+    -- Pick a target script output
+    target <- pickAny reducibleOutputs
 
-  counterexampleTM $
-    paragraph
-      [ "If this validates, the script's value validation is insufficient."
-      , "An attacker could exploit this to:"
-      , "1) Increase their balance without depositing matching funds"
-      , "2) Steal funds from pooled reserves"
-      , "3) Create inconsistency between datum balance and actual UTxO value"
-      ]
+    -- Calculate reduced value
+    let currentValue = valueOf target
+        currentAda = C.selectLovelace currentValue
+        -- Calculate reduced ADA, ensuring we don't go below minimum
+        -- Lovelace has a Num instance, so we can use numeric operations
+        reducedAda = max minOutputAda (fromInteger $ round (fromIntegral currentAda * (1 - reductionFactor)))
+        adaDifference = C.negateValue $ C.lovelaceToValue (currentAda - reducedAda)
+        reducedValue = currentValue <> adaDifference
 
-  -- This SHOULD fail - if it validates, the contract is vulnerable
-  -- The attack: reduce the ADA value but keep datum the same
-  shouldNotValidate $ changeValueOf target reducedValue
+    counterexampleTM $
+      paragraph
+        [ "The transaction contains a script output at index"
+        , show (outputIx target)
+        , "."
+        ]
+
+    counterexampleTM $
+      paragraph
+        [ "Testing if the ADA value can be reduced from"
+        , show currentAda
+        , "to"
+        , show reducedAda
+        , "(reduction factor:"
+        , show (reductionFactor * 100) ++ "%)"
+        , "while keeping the datum unchanged."
+        ]
+
+    counterexampleTM $
+      paragraph
+        [ "If this validates, the script's value validation is insufficient."
+        , "An attacker could exploit this to:"
+        , "1) Increase their balance without depositing matching funds"
+        , "2) Steal funds from pooled reserves"
+        , "3) Create inconsistency between datum balance and actual UTxO value"
+        ]
+
+    tabulateTM "reduction %" [bucketPct reductionFactor]
+
+    -- This SHOULD fail - if it validates, the contract is vulnerable
+    -- The attack: reduce the ADA value but keep datum the same
+    shouldNotValidate $ changeValueOf target reducedValue
+
+-- | Shrink a positive 'Double' toward 0, discarding non-positive results.
+shrinkPositiveDouble :: Double -> [Double]
+shrinkPositiveDouble = filter (> 0) . shrinkRealFrac
+
+-- | Coarse bucket for the reduction-factor distribution report.
+bucketPct :: Double -> String
+bucketPct r
+  | r <= 0.25 = "01-25%"
+  | r <= 0.50 = "26-50%"
+  | r <= 0.75 = "51-75%"
+  | otherwise = "76-99%"


### PR DESCRIPTION
Fixes #80 

- Add three-tier API to 6 parameterised threat models: model / modelWith / modelWithGen (LargeData, LargeValue, ValueUnderpayment, DatumByteBloat, DatumListBloat, InvalidDatumIndex)
- Parameters now drawn per-transaction via forAllTM instead of fixed at definition time, letting QuickCheck explore the parameter space
- Fix Monitor/MonitorLocal being silently dropped in runThreatModelCheck(Traced), so tabulateTM/collectTM/classifyTM now surface in propRunActions output
- Add missing script-spend precondition to datumListBloatAttack and datumByteBloatAttack (was firing on lock-only transactions with no validator, causing false positives exposed by the randomisation)
- Document the three-tier convention in 06-threat-models.md (new §G) and cross-reference from 03-testing-interface-class.md