### PR TITLE
Fixing TestingInterface slot handling and update use-cases accordingly.

### DIFF
--- a/src/testing-interface/lib/Convex/ThreatModel.hs
+++ b/src/testing-interface/lib/Convex/ThreatModel.hs
@@ -333,13 +333,13 @@ runThreatModel = go False
 assertThreatModel
   :: ThreatModel a
   -> LedgerProtocolParameters Era
-  -> [(Tx Era, UTxO Era)]
+  -> [(Tx Era, UTxO Era, SlotNo)]
   -> Property
 assertThreatModel m pparams' txs = runThreatModel m envs
  where
   envs =
-    [ ThreatModelEnv tx utxo 0 pparams'
-    | (tx, utxo) <- txs
+    [ ThreatModelEnv tx utxo slot pparams'
+    | (tx, utxo, slot) <- txs
     ]
 
 {- | Run threat model inside MockchainT with full Phase 1 + Phase 2 validation.

--- a/src/testing-interface/lib/Convex/ThreatModel.hs
+++ b/src/testing-interface/lib/Convex/ThreatModel.hs
@@ -155,7 +155,7 @@ import Text.Printf
 import Test.QuickCheck
 import Test.QuickCheck qualified as QC
 
-import Convex.Class (MockChainState, MonadMockchain (..), coverageData, getUtxo, setTimeToValidRange)
+import Convex.Class (MockChainState, MonadMockchain (..), coverageData, getSlot, getUtxo, setTimeToValidRange)
 import Convex.MockChain (applyTransaction, runMockchain)
 import Convex.NodeParams (NodeParams, ledgerProtocolParameters)
 import Convex.ThreatModel.Cardano.Api
@@ -174,13 +174,14 @@ transactions in counterexamples. To include more information you can use `counte
 the functions below.
 -}
 
-{- | The context in which a `ThreatModel` is executed. Contains a transaction, its UTxO set and the
-  protocol parameters. See `getThreatModelEnv` and `originalTx` to access this information in a
-  threat model.
+{- | The context in which a `ThreatModel` is executed. Contains a transaction, its UTxO set, the
+  replayed slot, and the protocol parameters. See `getThreatModelEnv` and `originalTx` to access
+  this information in a threat model.
 -}
 data ThreatModelEnv = ThreatModelEnv
   { currentTx :: Tx Era
   , currentUTxOs :: UTxO Era
+  , currentSlot :: SlotNo
   , pparams :: LedgerProtocolParameters Era
   }
 
@@ -198,12 +199,13 @@ threatModelEnvs params txs chainState0 = fst $ foldM go chainState0 txs
   go chainState tx =
     let txBodyContent = getTxBodyContent $ getTxBody tx
         rng = (txValidityLowerBound txBodyContent, txValidityUpperBound txBodyContent)
-        (utxo, chainState') = runMockchain (setTimeToValidRange rng >> getUtxo) params chainState
+        ((slot, utxo), chainState') = runMockchain (setTimeToValidRange rng >> ((,) <$> getSlot <*> getUtxo)) params chainState
         res = applyTransaction params chainState' tx
         threatModelEnv =
           ThreatModelEnv
             { currentTx = tx
             , currentUTxOs = fromLedgerUTxO shelleyBasedEra utxo
+            , currentSlot = slot
             , pparams = params ^. ledgerProtocolParameters
             }
      in case res of
@@ -336,7 +338,7 @@ assertThreatModel
 assertThreatModel m pparams' txs = runThreatModel m envs
  where
   envs =
-    [ ThreatModelEnv tx utxo pparams'
+    [ ThreatModelEnv tx utxo 0 pparams'
     | (tx, utxo) <- txs
     ]
 
@@ -433,7 +435,7 @@ runThreatModelM' quiet signingWallet = go False
         params <- askNodeParams
         rebalancedTx <- rebalanceAndSignM wallet modifiedTx modifiedUtxo
         -- Validate with full Phase 1 + Phase 2
-        (report, covData) <- validateTxM params rebalancedTx modifiedUtxo
+        (report, covData) <- validateTxM params (currentSlot env) rebalancedTx modifiedUtxo
         -- Accumulate coverage into the running MockChainState
         modifyMockChainState $ \s -> ((), s & coverageData %~ (<> covData))
         interpM mon wallet (k report)
@@ -495,7 +497,7 @@ runThreatModelCheck signingWallet = go False
           Left _err ->
             go b model envs -- Rebalancing failed, skip to next tx (like precondition failure)
           Right rebalancedTx -> do
-            (report, covData) <- validateTxM params rebalancedTx modifiedUtxo
+            (report, covData) <- validateTxM params (currentSlot env) rebalancedTx modifiedUtxo
             modifyMockChainState $ \s -> ((), s & coverageData %~ (<> covData))
             checkInterp wallet (k report)
       Generate gen _shr k -> do
@@ -571,7 +573,7 @@ runThreatModelCheckTraced signingWallet = go False [] 0
                     }
             go b (entry : acc') (envIdx + 1) model envs -- Rebalancing failed, skip to next tx
           Right rebalancedTx -> do
-            (report, covData) <- validateTxM params rebalancedTx modifiedUtxo
+            (report, covData) <- validateTxM params (currentSlot env) rebalancedTx modifiedUtxo
             modifyMockChainState $ \s -> ((), s & coverageData %~ (<> covData))
             let entry =
                   ThreatModelCheckEntry
@@ -663,7 +665,7 @@ shouldNotValidate = shouldValidateOrNot False
 shouldValidateOrNot :: Bool -> TxModifier -> ThreatModel ()
 shouldValidateOrNot should txMod = do
   validReport <- validate txMod
-  ThreatModelEnv tx utxos _ <- getThreatModelEnv
+  ThreatModelEnv tx utxos _ _ <- getThreatModelEnv
   let newTx = fst $ applyTxModifier tx utxos txMod
       info str =
         block
@@ -713,7 +715,7 @@ getTxOutputs = zipWith (flip Output . TxIx) [0 ..] . txOutputs <$> originalTx
 -- | Get the inputs from the original transaction.
 getTxInputs :: ThreatModel [Input]
 getTxInputs = do
-  ThreatModelEnv tx (UTxO utxos) _ <- getThreatModelEnv
+  ThreatModelEnv tx (UTxO utxos) _ _ <- getThreatModelEnv
   pure
     [ Input txout i
     | i <- txInputs tx
@@ -723,7 +725,7 @@ getTxInputs = do
 -- | Get the reference inputs from the original transaction.
 getTxReferenceInputs :: ThreatModel [Input]
 getTxReferenceInputs = do
-  ThreatModelEnv tx (UTxO utxos) _ <- getThreatModelEnv
+  ThreatModelEnv tx (UTxO utxos) _ _ <- getThreatModelEnv
   pure
     [ Input txout i
     | i <- txReferenceInputs tx

--- a/src/testing-interface/lib/Convex/ThreatModel/Cardano/Api.hs
+++ b/src/testing-interface/lib/Convex/ThreatModel/Cardano/Api.hs
@@ -119,7 +119,6 @@ import Convex.Class (
   ValidationError (..),
   coverageData,
   env,
-  getSlot,
   poolState,
  )
 import Convex.MockChain (applyTransaction, initialState)
@@ -503,11 +502,11 @@ This uses 'applyTransaction' which performs complete ledger validation including
 validateTxM
   :: (MonadMockchain Era m)
   => NodeParams Era
+  -> SlotNo
   -> Tx Era
   -> UTxO Era
   -> m (ValidityReport, CoverageData)
-validateTxM params tx utxo = do
-  slot <- getSlot
+validateTxM params slot tx utxo = do
   let mockState = buildMockState params slot utxo
   pure $ case applyTransaction params mockState tx of
     Left (MockchainError (VExUnits (Phase2Error (ScriptErrorEvaluationFailed DebugPlutusFailure{dpfEvaluationError, dpfExecutionLogs})))) ->

--- a/src/testing-interface/lib/Convex/ThreatModel/InputDuplication.hs
+++ b/src/testing-interface/lib/Convex/ThreatModel/InputDuplication.hs
@@ -61,7 +61,7 @@ UTxOs are available.
 inputDuplication :: ThreatModel ()
 inputDuplication = Named "Input Duplication" $ do
   -- Get the environment to access the full UTxO set and the original transaction
-  ThreatModelEnv tx (C.UTxO utxoMap) _ <- getThreatModelEnv
+  ThreatModelEnv tx (C.UTxO utxoMap) _ _ <- getThreatModelEnv
 
   -- Find a script input (non-key address = script address)
   scriptInput <- anyInputSuchThat (not . isKeyAddressAny . addressOf)

--- a/src/testing-interface/test/AikenKingOfCardanoSpec.hs
+++ b/src/testing-interface/test/AikenKingOfCardanoSpec.hs
@@ -54,7 +54,7 @@ import Convex.Aiken.Blueprint (Blueprint (..))
 import Convex.Aiken.Blueprint qualified as Blueprint
 import Convex.BuildTx (MonadBuildTx, execBuildTx)
 import Convex.BuildTx qualified as BuildTx
-import Convex.Class (MonadMockchain, getUtxo)
+import Convex.Class (MonadMockchain, getSlot, getUtxo)
 import Convex.CoinSelection (BalanceTxError, ChangeOutputPosition (TrailingChange))
 import Convex.MockChain (fromLedgerUTxO, runMockchain0IOWith)
 import Convex.MockChain.CoinSelection (balanceAndSubmit, tryBalanceAndSubmit)
@@ -694,12 +694,14 @@ propKingUnprotectedOutput opts = monadicIO $ do
     runMockchain0IOWith Wallet.initialUTxOs params $
       runExceptT $ do
         (tx, utxo) <- kingScenario
+        slot <- getSlot
 
         let pparams' = params ^. ledgerProtocolParameters
             env =
               ThreatModelEnv
                 { currentTx = tx
                 , currentUTxOs = utxo
+                , currentSlot = slot
                 , pparams = pparams'
                 }
 

--- a/src/testing-interface/test/AikenLendingSpec.hs
+++ b/src/testing-interface/test/AikenLendingSpec.hs
@@ -62,7 +62,7 @@ import Convex.Aiken.Blueprint (Blueprint (..))
 import Convex.Aiken.Blueprint qualified as Blueprint
 import Convex.BuildTx (MonadBuildTx, execBuildTx)
 import Convex.BuildTx qualified as BuildTx
-import Convex.Class (MonadMockchain, getUtxo)
+import Convex.Class (MonadMockchain, getSlot, getUtxo)
 import Convex.CoinSelection (ChangeOutputPosition (TrailingChange))
 import Convex.MockChain (fromLedgerUTxO, runMockchain0IOWith)
 import Convex.MockChain.CoinSelection (balanceAndSubmit, tryBalanceAndSubmit)
@@ -708,12 +708,14 @@ propLendingVulnerableToInputDuplication opts = QC.expectFailure $
               -- Fund ONLY the first loan with a valid transaction
               let lendTxBody = execBuildTx $ lendFunds Defaults.networkId txIn1 datum1 value1 Wallet.w3
               lendTx <- tryBalanceAndSubmit mempty Wallet.w3 lendTxBody TrailingChange []
+              slot <- getSlot
 
               let pparams' = params ^. ledgerProtocolParameters
                   env =
                     ThreatModelEnv
                       { currentTx = lendTx
                       , currentUTxOs = utxoBefore
+                      , currentSlot = slot
                       , pparams = pparams'
                       }
 

--- a/src/testing-interface/test/BountySpec.hs
+++ b/src/testing-interface/test/BountySpec.hs
@@ -22,6 +22,7 @@ import Convex.BuildTx (execBuildTx)
 import Convex.BuildTx qualified as BuildTx
 import Convex.Class (
   MonadMockchain,
+  getSlot,
   getUtxo,
  )
 import Convex.CoinSelection (BalanceTxError, ChangeOutputPosition (TrailingChange))
@@ -101,12 +102,14 @@ propBountyVulnerableToDoubleSatisfaction opts = QC.expectFailure $
       runMockchain0IOWith Wallet.initialUTxOs params $
         runExceptT $ do
           (tx, utxo) <- bountyVulnerableScenario
+          slot <- getSlot
 
           let pparams' = params ^. ledgerProtocolParameters
               env =
                 ThreatModelEnv
                   { currentTx = tx
                   , currentUTxOs = utxo
+                  , currentSlot = slot
                   , pparams = pparams'
                   }
 
@@ -191,12 +194,14 @@ propBountySecureAgainstDoubleSatisfaction opts = monadicIO $ do
     runMockchain0IOWith Wallet.initialUTxOs params $
       runExceptT $ do
         (tx, utxo) <- bountySecureScenario
+        slot <- getSlot
 
         let pparams' = params ^. ledgerProtocolParameters
             env =
               ThreatModelEnv
                 { currentTx = tx
                 , currentUTxOs = utxo
+                , currentSlot = slot
                 , pparams = pparams'
                 }
 

--- a/src/testing-interface/test/PingPongSpec.hs
+++ b/src/testing-interface/test/PingPongSpec.hs
@@ -523,6 +523,7 @@ propPingPongWithThreatModel opts = monadicIO $ do
             [ ThreatModelEnv
                 { currentTx = tx
                 , currentUTxOs = utxo
+                , currentSlot = 0
                 , pparams = pparams'
                 }
             | tx <- txs
@@ -560,12 +561,14 @@ propPingPongVulnerableToOutputRedirect opts = QC.expectFailure $
       runMockchain0IOWith Wallet.initialUTxOs params $
         runExceptT $ do
           (tx, utxo) <- vulnerablePingPongScenario
+          slot <- Convex.Class.getSlot
 
           let pparams' = params ^. ledgerProtocolParameters
               env =
                 ThreatModelEnv
                   { currentTx = tx
                   , currentUTxOs = utxo
+                  , currentSlot = slot
                   , pparams = pparams'
                   }
 
@@ -639,12 +642,14 @@ propPingPongVulnerableToLargeData opts = QC.expectFailure $
       runMockchain0IOWith Wallet.initialUTxOs params $
         runExceptT $ do
           (tx, utxo) <- vulnerablePingPongLargeDataScenario
+          slot <- Convex.Class.getSlot
 
           let pparams' = params ^. ledgerProtocolParameters
               env =
                 ThreatModelEnv
                   { currentTx = tx
                   , currentUTxOs = utxo
+                  , currentSlot = slot
                   , pparams = pparams'
                   }
 
@@ -722,12 +727,14 @@ propPingPongVulnerableToLargeValue opts = QC.expectFailure $
       runMockchain0IOWith Wallet.initialUTxOs params $
         runExceptT $ do
           (tx, utxo) <- vulnerablePingPongLargeValueScenario
+          slot <- Convex.Class.getSlot
 
           let pparams' = params ^. ledgerProtocolParameters
               env =
                 ThreatModelEnv
                   { currentTx = tx
                   , currentUTxOs = utxo
+                  , currentSlot = slot
                   , pparams = pparams'
                   }
 

--- a/src/testing-interface/test/PingPongSpec.hs
+++ b/src/testing-interface/test/PingPongSpec.hs
@@ -509,11 +509,13 @@ propPingPongWithThreatModel opts = monadicIO $ do
     txs <- Convex.Class.getTxs
     -- Get the current UTxO set
     ledgerUtxo <- Convex.Class.getUtxo
-    pure (txs, ledgerUtxo)
+    -- Get the current slot
+    slot <- Convex.Class.getSlot
+    pure (txs, ledgerUtxo, slot)
 
   case result of
     (Left err, _) -> fail (show err)
-    (Right (txs, ledgerUtxo), _finalState) -> do
+    (Right (txs, ledgerUtxo, slot), _finalState) -> do
       -- Convert ledger UTxO to cardano-api UTxO
       let utxo = fromLedgerUTxO C.shelleyBasedEra ledgerUtxo
           pparams' = params ^. ledgerProtocolParameters
@@ -523,7 +525,7 @@ propPingPongWithThreatModel opts = monadicIO $ do
             [ ThreatModelEnv
                 { currentTx = tx
                 , currentUTxOs = utxo
-                , currentSlot = 0
+                , currentSlot = slot
                 , pparams = pparams'
                 }
             | tx <- txs

--- a/src/use-cases/test/Auction/Spec/Prop.hs
+++ b/src/use-cases/test/Auction/Spec/Prop.hs
@@ -22,9 +22,24 @@ import Convex.MockChain.Defaults qualified as Defaults
 import Convex.PlutusLedger.V1 (transPubKeyHash, unTransAssetName)
 import Convex.Tasty.QuickCheck qualified as QC
 import Convex.TestingInterface (TestingInterface (..), ThreatModelsFor (..), propRunActions)
+import Convex.ThreatModel.DatumBloat (datumByteBloatAttack, datumListBloatAttack)
 import Convex.ThreatModel.DoubleSatisfaction (doubleSatisfaction)
+import Convex.ThreatModel.DuplicateListEntry (duplicateListEntryAttack)
+import Convex.ThreatModel.InputDuplication (inputDuplication)
+import Convex.ThreatModel.InvalidDatumIndex (invalidDatumIndexAttack)
+import Convex.ThreatModel.LargeData (largeDataAttack)
+import Convex.ThreatModel.LargeValue (largeValueAttack)
+import Convex.ThreatModel.MissingOutputDatum (missingOutputDatumAttack)
+import Convex.ThreatModel.MutualExclusion (mutualExclusionAttack)
+import Convex.ThreatModel.NegativeInteger (negativeIntegerAttack)
+import Convex.ThreatModel.OutputDatumHashMissing (outputDatumHashMissingAttack)
+import Convex.ThreatModel.RedeemerAssetSubstitution (redeemerAssetSubstitution)
+import Convex.ThreatModel.SelfReferenceInjection (selfReferenceInjection)
+import Convex.ThreatModel.SignatoryRemoval (signatoryRemoval)
 import Convex.ThreatModel.TimeBoundManipulation (timeBoundManipulation)
 import Convex.ThreatModel.TokenForgery (simpleAlwaysSucceedsMintingPolicyV2, simpleTestAssetName, tokenForgeryAttack)
+import Convex.ThreatModel.UnprotectedScriptOutput (unprotectedScriptOutput)
+import Convex.ThreatModel.ValueUnderpayment (valueUnderpaymentAttack)
 import Convex.Utils (slotToUtcTime, utcTimeToPosixTime)
 import Convex.Wallet (Wallet, verificationKeyHash)
 import Convex.Wallet qualified as MockWallet
@@ -260,14 +275,23 @@ instance TestingInterface AuctionModel where
   monitoring _ _ = id
 
 instance ThreatModelsFor AuctionModel where
-  threatModels = [doubleSatisfaction]
-  expectedVulnerabilities = [timeBoundManipulation, tokenForgeryAttack simpleAlwaysSucceedsMintingPolicyV2 simpleTestAssetName]
-
--- threatModels = [doubleSatisfaction, datumListBloatAttack, datumByteBloatAttack, duplicateListEntryAttack
---                , largeDataAttackWith 10, largeValueAttackWith 10, inputDuplication, mutualExclusionAttack
---                , negativeIntegerAttack, redeemerAssetSubstitution, selfReferenceInjection, signatoryRemoval
---                , timeBoundManipulation, tokenForgeryAttack simpleAlwaysSucceedsMintingPolicyV2 simpleTestAssetName
---                , unprotectedScriptOutput , unprotectedScriptOutput, valueUnderpaymentAttack]
+  threatModels =
+    [ datumListBloatAttack
+    , datumByteBloatAttack
+    , duplicateListEntryAttack
+    , inputDuplication
+    , invalidDatumIndexAttack
+    , missingOutputDatumAttack
+    , mutualExclusionAttack
+    , negativeIntegerAttack
+    , outputDatumHashMissingAttack
+    , redeemerAssetSubstitution
+    , selfReferenceInjection
+    , signatoryRemoval
+    , unprotectedScriptOutput
+    , valueUnderpaymentAttack
+    ]
+  expectedVulnerabilities = [doubleSatisfaction, largeDataAttack, largeValueAttack, timeBoundManipulation, tokenForgeryAttack simpleAlwaysSucceedsMintingPolicyV2 simpleTestAssetName]
 
 -------------------------------------------------------------------------------
 -- Helper functions for the AuctionModel

--- a/src/use-cases/test/Escrow/Spec/Prop.hs
+++ b/src/use-cases/test/Escrow/Spec/Prop.hs
@@ -22,12 +22,23 @@ import Convex.MockChain.Defaults qualified as Defaults
 import Convex.PlutusLedger.V1 (transPubKeyHash)
 import Convex.Tasty.QuickCheck qualified as QC
 import Convex.TestingInterface (TestingInterface (..), ThreatModelsFor (expectedVulnerabilities, threatModels), propRunActions)
+import Convex.ThreatModel.DatumBloat (datumByteBloatAttack, datumListBloatAttack)
 import Convex.ThreatModel.DoubleSatisfaction (doubleSatisfaction)
-import Convex.ThreatModel.LargeValue (largeValueAttackWith)
+import Convex.ThreatModel.DuplicateListEntry (duplicateListEntryAttack)
+import Convex.ThreatModel.InputDuplication (inputDuplication)
+import Convex.ThreatModel.InvalidDatumIndex (invalidDatumIndexAttack)
+import Convex.ThreatModel.LargeData (largeDataAttack)
+import Convex.ThreatModel.LargeValue (largeValueAttack)
+import Convex.ThreatModel.MissingOutputDatum (missingOutputDatumAttack)
 import Convex.ThreatModel.MutualExclusion (mutualExclusionAttack)
+import Convex.ThreatModel.NegativeInteger (negativeIntegerAttack)
+import Convex.ThreatModel.OutputDatumHashMissing (outputDatumHashMissingAttack)
+import Convex.ThreatModel.RedeemerAssetSubstitution (redeemerAssetSubstitution)
+import Convex.ThreatModel.SelfReferenceInjection (selfReferenceInjection)
 import Convex.ThreatModel.SignatoryRemoval (signatoryRemoval)
 import Convex.ThreatModel.TimeBoundManipulation (timeBoundManipulation)
 import Convex.ThreatModel.TokenForgery (simpleAlwaysSucceedsMintingPolicyV2, simpleTestAssetName, tokenForgeryAttack)
+import Convex.ThreatModel.UnprotectedScriptOutput (unprotectedScriptOutput)
 import Convex.ThreatModel.ValueUnderpayment (valueUnderpaymentAttack)
 import Convex.Utils (slotToUtcTime, utcTimeToPosixTime)
 import Convex.Utxos (toApiUtxo)
@@ -213,14 +224,28 @@ instance TestingInterface EscrowModel where
 
 instance ThreatModelsFor EscrowModel where
   threatModels =
-    [ doubleSatisfaction
-    , largeValueAttackWith 10
+    [ datumListBloatAttack
+    , datumByteBloatAttack
+    , duplicateListEntryAttack
+    , inputDuplication
+    , invalidDatumIndexAttack
+    , largeDataAttack
+    , largeValueAttack
+    , missingOutputDatumAttack
     , mutualExclusionAttack
+    , negativeIntegerAttack
+    , outputDatumHashMissingAttack
+    , redeemerAssetSubstitution
+    , selfReferenceInjection
     , signatoryRemoval
-    , tokenForgeryAttack simpleAlwaysSucceedsMintingPolicyV2 simpleTestAssetName
+    , unprotectedScriptOutput
     , valueUnderpaymentAttack
     ]
-  expectedVulnerabilities = [timeBoundManipulation]
+  expectedVulnerabilities =
+    [ doubleSatisfaction
+    , timeBoundManipulation
+    , tokenForgeryAttack simpleAlwaysSucceedsMintingPolicyV2 simpleTestAssetName
+    ]
 
 -------------------------------------------------------------------------------
 -- Helpers

--- a/src/use-cases/test/MultiPlayerPingPong/Spec/Prop.hs
+++ b/src/use-cases/test/MultiPlayerPingPong/Spec/Prop.hs
@@ -21,16 +21,24 @@ import Convex.MockChain.Defaults qualified as Defaults
 import Convex.PlutusLedger.V1 (transPubKeyHash)
 import Convex.Tasty.QuickCheck qualified as QC
 import Convex.TestingInterface (TestingInterface (..), ThreatModelsFor (..), propRunActions)
-import Convex.ThreatModel.DatumBloat (datumListBloatAttack)
+import Convex.ThreatModel.DatumBloat (datumByteBloatAttack, datumListBloatAttack)
+import Convex.ThreatModel.DoubleSatisfaction (doubleSatisfaction)
 import Convex.ThreatModel.DuplicateListEntry (duplicateListEntryAttack)
-import Convex.ThreatModel.LargeData (largeDataAttackWith)
-import Convex.ThreatModel.LargeValue (largeValueAttackWith)
+import Convex.ThreatModel.InputDuplication (inputDuplication)
+import Convex.ThreatModel.InvalidDatumIndex (invalidDatumIndexAttack)
+import Convex.ThreatModel.LargeData (largeDataAttack)
+import Convex.ThreatModel.LargeValue (largeValueAttack)
+import Convex.ThreatModel.MissingOutputDatum (missingOutputDatumAttack)
 import Convex.ThreatModel.MutualExclusion (mutualExclusionAttack)
 import Convex.ThreatModel.NegativeInteger (negativeIntegerAttack)
+import Convex.ThreatModel.OutputDatumHashMissing (outputDatumHashMissingAttack)
+import Convex.ThreatModel.RedeemerAssetSubstitution (redeemerAssetSubstitution)
+import Convex.ThreatModel.SelfReferenceInjection (selfReferenceInjection)
 import Convex.ThreatModel.SignatoryRemoval (signatoryRemoval)
 import Convex.ThreatModel.TimeBoundManipulation (timeBoundManipulation)
 import Convex.ThreatModel.TokenForgery (simpleAlwaysSucceedsMintingPolicyV2, simpleTestAssetName, tokenForgeryAttack)
 import Convex.ThreatModel.UnprotectedScriptOutput (unprotectedScriptOutput)
+import Convex.ThreatModel.ValueUnderpayment (valueUnderpaymentAttack)
 import Convex.Utxos (toApiUtxo)
 import Convex.Wallet (Wallet, verificationKeyHash)
 import Convex.Wallet.MockWallet qualified as MockWallet
@@ -258,14 +266,22 @@ nextStateForHitTurn m =
 instance ThreatModelsFor MultiPlayerPingPongModel where
   threatModels =
     [ datumListBloatAttack
-    , largeDataAttackWith 10
-    , largeValueAttackWith 10
+    , datumByteBloatAttack
+    , doubleSatisfaction
+    , inputDuplication
+    , invalidDatumIndexAttack
+    , largeDataAttack
+    , largeValueAttack
+    , missingOutputDatumAttack
     , mutualExclusionAttack
     , negativeIntegerAttack
+    , outputDatumHashMissingAttack
+    , redeemerAssetSubstitution
+    , selfReferenceInjection
     , signatoryRemoval
     , unprotectedScriptOutput
+    , valueUnderpaymentAttack
     ]
-
   expectedVulnerabilities =
     [ duplicateListEntryAttack
     , timeBoundManipulation

--- a/src/use-cases/test/Vesting/Spec/Prop.hs
+++ b/src/use-cases/test/Vesting/Spec/Prop.hs
@@ -19,8 +19,19 @@ import Convex.MockChain.Defaults qualified as Defaults
 import Convex.PlutusLedger.V1 (transPubKeyHash)
 import Convex.Tasty.QuickCheck qualified as QC
 import Convex.TestingInterface (RunOptions, TestingInterface (..), ThreatModelsFor (..), propRunActionsWithOptions)
-import Convex.ThreatModel.LargeValue (largeValueAttackWith)
+import Convex.ThreatModel.DatumBloat (datumByteBloatAttack, datumListBloatAttack)
+import Convex.ThreatModel.DoubleSatisfaction (doubleSatisfaction)
+import Convex.ThreatModel.DuplicateListEntry (duplicateListEntryAttack)
+import Convex.ThreatModel.InputDuplication (inputDuplication)
+import Convex.ThreatModel.InvalidDatumIndex (invalidDatumIndexAttack)
+import Convex.ThreatModel.LargeData (largeDataAttack)
+import Convex.ThreatModel.LargeValue (largeValueAttack)
+import Convex.ThreatModel.MissingOutputDatum (missingOutputDatumAttack)
 import Convex.ThreatModel.MutualExclusion (mutualExclusionAttack)
+import Convex.ThreatModel.NegativeInteger (negativeIntegerAttack)
+import Convex.ThreatModel.OutputDatumHashMissing (outputDatumHashMissingAttack)
+import Convex.ThreatModel.RedeemerAssetSubstitution (redeemerAssetSubstitution)
+import Convex.ThreatModel.SelfReferenceInjection (selfReferenceInjection)
 import Convex.ThreatModel.SignatoryRemoval (signatoryRemoval)
 import Convex.ThreatModel.TimeBoundManipulation (timeBoundManipulation)
 import Convex.ThreatModel.TokenForgery (simpleAlwaysSucceedsMintingPolicyV2, simpleTestAssetName, tokenForgeryAttack)
@@ -229,16 +240,27 @@ instance TestingInterface VestingModel where
 
 instance ThreatModelsFor VestingModel where
   threatModels =
-    [ largeValueAttackWith 10
+    [ datumListBloatAttack
+    , datumByteBloatAttack
+    , doubleSatisfaction
+    , duplicateListEntryAttack
+    , inputDuplication
     , mutualExclusionAttack
+    , negativeIntegerAttack
+    , redeemerAssetSubstitution
+    , selfReferenceInjection
     , signatoryRemoval
-    , tokenForgeryAttack simpleAlwaysSucceedsMintingPolicyV2 simpleTestAssetName
-    , unprotectedScriptOutput
     , valueUnderpaymentAttack
     ]
-
   expectedVulnerabilities =
-    [ timeBoundManipulation
+    [ invalidDatumIndexAttack
+    , largeDataAttack
+    , largeValueAttack
+    , missingOutputDatumAttack
+    , outputDatumHashMissingAttack
+    , timeBoundManipulation
+    , tokenForgeryAttack simpleAlwaysSucceedsMintingPolicyV2 simpleTestAssetName
+    , unprotectedScriptOutput
     ]
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request makes several important improvements to the threat modeling and testing infrastructure, primarily by introducing slot tracking to the `ThreatModelEnv` and propagating this information throughout the codebase, to fix the problem of calling `getSlot` and always receiving zero as return.

**Key changes:**

### Threat Model Environment and Slot Tracking

* The `ThreatModelEnv` now includes a `currentSlot` field, representing the slot at which the transaction is replayed. This slot is properly computed and threaded through all relevant code paths, including test cases and threat model execution functions. (`[[1]](diffhunk://#diff-fbca1c12f7cd927134e33ade63ac8d55dcb57d9a5af788decf0cdd09870d780aL177-R184)`, `[[2]](diffhunk://#diff-fbca1c12f7cd927134e33ade63ac8d55dcb57d9a5af788decf0cdd09870d780aL201-R208)`, `[[3]](diffhunk://#diff-dd446ff75944c49f1eaea47981a431883b4dfcbbed0e5b67d0bb114d16bd3d64R697-R704)`, `[[4]](diffhunk://#diff-6278a8437d4987ab00d4eb460c4dd8f27f921cba3274305e0b72f2656ed326cbR711-R718)`, `[[5]](diffhunk://#diff-75eb82c5b2e7caccf194f2f17716b3c67597e60d3c7950bb2957121bb51b15e4R105-R112)`, `[[6]](diffhunk://#diff-75eb82c5b2e7caccf194f2f17716b3c67597e60d3c7950bb2957121bb51b15e4R197-R204)`, `[[7]](diffhunk://#diff-58953eb4c1473255f43cda851fc67d8a425b292cca47751a85f99120d41b15f8R526)`, `[[8]](diffhunk://#diff-58953eb4c1473255f43cda851fc67d8a425b292cca47751a85f99120d41b15f8R564-R571)`, `[[9]](diffhunk://#diff-58953eb4c1473255f43cda851fc67d8a425b292cca47751a85f99120d41b15f8R645-R652)`, `[[10]](diffhunk://#diff-58953eb4c1473255f43cda851fc67d8a425b292cca47751a85f99120d41b15f8R730-R737)`)
* All usages of `ThreatModelEnv` and related pattern matches are updated to accommodate the new `currentSlot` field. (`[[1]](diffhunk://#diff-fbca1c12f7cd927134e33ade63ac8d55dcb57d9a5af788decf0cdd09870d780aL339-R341)`, `[[2]](diffhunk://#diff-fbca1c12f7cd927134e33ade63ac8d55dcb57d9a5af788decf0cdd09870d780aL666-R668)`, `[[3]](diffhunk://#diff-fbca1c12f7cd927134e33ade63ac8d55dcb57d9a5af788decf0cdd09870d780aL716-R718)`, `[[4]](diffhunk://#diff-fbca1c12f7cd927134e33ade63ac8d55dcb57d9a5af788decf0cdd09870d780aL726-R728)`, `[[5]](diffhunk://#diff-64fc512deaa45203848da4a2116994808d873951b37d832e15ce65519ed381f7L64-R64)`)

### Validation and Mockchain Updates

* The `validateTxM` function now requires the slot as an explicit argument, eliminating the need to call `getSlot` internally and ensuring more accurate and deterministic validation. All calls to `validateTxM` are updated accordingly. (`[[1]](diffhunk://#diff-fbca1c12f7cd927134e33ade63ac8d55dcb57d9a5af788decf0cdd09870d780aL436-R438)`, `[[2]](diffhunk://#diff-fbca1c12f7cd927134e33ade63ac8d55dcb57d9a5af788decf0cdd09870d780aL498-R500)`, `[[3]](diffhunk://#diff-fbca1c12f7cd927134e33ade63ac8d55dcb57d9a5af788decf0cdd09870d780aL574-R576)`, `[[4]](diffhunk://#diff-5cfd79d504761e2ed459705774c1e64a83fbdf62616b5eb32ceeaaac2eaaabb2R505-R509)`)
* Imports are updated to reflect the new usage patterns, adding or removing `getSlot` as appropriate. (`[[1]](diffhunk://#diff-fbca1c12f7cd927134e33ade63ac8d55dcb57d9a5af788decf0cdd09870d780aL158-R158)`, `[[2]](diffhunk://#diff-5cfd79d504761e2ed459705774c1e64a83fbdf62616b5eb32ceeaaac2eaaabb2L122)`, `[[3]](diffhunk://#diff-dd446ff75944c49f1eaea47981a431883b4dfcbbed0e5b67d0bb114d16bd3d64L57-R57)`, `[[4]](diffhunk://#diff-6278a8437d4987ab00d4eb460c4dd8f27f921cba3274305e0b72f2656ed326cbL65-R65)`, `[[5]](diffhunk://#diff-75eb82c5b2e7caccf194f2f17716b3c67597e60d3c7950bb2957121bb51b15e4R25)`)

### Threat Model Test Coverage

* The use-cases where updated to use all ThreatModels.